### PR TITLE
feat: configurable active hours for the chatbot

### DIFF
--- a/apps/backend/src/routes/chat-routes.ts
+++ b/apps/backend/src/routes/chat-routes.ts
@@ -26,6 +26,7 @@ import {
   authenticateChatAccess,
 } from '../middleware/auth-middleware'
 import { getChatConfigByCompanyId } from '../db/chat-configs'
+import { isBotActive } from '../services/utils/chat-availability'
 import {
   retrieveDocuments,
   formatDocumentsAsContext
@@ -37,6 +38,31 @@ import type { Message, ChatSettings } from '../services/openai-service'
 import { sendInquiryEmail } from '../services/sendgrid-service'
 
 const router = express.Router()
+
+// Public endpoint: report whether the bot is currently within its active hours.
+// Used by the widget to decide whether to render at all. Must be declared before
+// the `/:chatId` route so it isn't captured as a chat ID.
+router.get('/availability', async (req, res) => {
+  try {
+    const companyId = req.query.companyId
+
+    if (!companyId || typeof companyId !== 'string') {
+      return res.status(400).json({ error: 'Company ID is required' })
+    }
+
+    const chatConfig = await getChatConfigByCompanyId(companyId)
+    if (!chatConfig) {
+      return res.status(404).json({ error: 'Chat config not found' })
+    }
+
+    return res.json({ available: isBotActive(chatConfig) })
+  } catch (error) {
+    logger.error('Error checking chat availability', {
+      error: error as Error
+    })
+    return res.status(500).json({ error: 'Failed to check availability' })
+  }
+})
 
 /**
  * Enhances a user query with conversation context for better semantic search.
@@ -504,6 +530,11 @@ router.post('/stream-ai-sdk', authenticateChatAccess, async (req: CustomRequest,
     const chatConfig = await getChatConfigByCompanyId(companyId as string);
     if (!chatConfig) {
       return res.status(400).json({ error: 'Company configuration not found' });
+    }
+
+    // Reject messages received outside the bot's configured active hours.
+    if (!isBotActive(chatConfig)) {
+      return res.status(403).json({ error: 'The chatbot is currently offline' });
     }
 
     let docsContext = ''

--- a/apps/backend/src/services/utils/chat-availability.ts
+++ b/apps/backend/src/services/utils/chat-availability.ts
@@ -1,0 +1,100 @@
+import type { Tables } from '../../types/database'
+
+type ChatConfig = Tables<'chat_configs'>
+
+type ActiveHoursConfig = Pick<
+  ChatConfig,
+  'timezone' | 'active_start_time' | 'active_end_time'
+>
+
+/**
+ * Convert a "HH:MM" / "HH:MM:SS" time string into minutes since midnight.
+ * Returns undefined if the value can't be parsed.
+ */
+const timeStringToMinutes = (time: string): number | undefined => {
+  const match = /^(\d{1,2}):(\d{2})/.exec(time.trim())
+  if (!match) return undefined
+
+  const hours = Number(match[1])
+  const minutes = Number(match[2])
+
+  if (
+    !Number.isFinite(hours) ||
+    !Number.isFinite(minutes) ||
+    hours > 24 ||
+    minutes > 59
+  ) {
+    return undefined
+  }
+
+  return hours * 60 + minutes
+}
+
+/**
+ * Get the current minutes-since-midnight in the given IANA timezone.
+ * Falls back to undefined if the timezone is invalid.
+ */
+const currentMinutesInTimezone = (timezone: string): number | undefined => {
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      hour12: false,
+      hour: '2-digit',
+      minute: '2-digit'
+    }).formatToParts(new Date())
+
+    const hourPart = parts.find(part => part.type === 'hour')?.value
+    const minutePart = parts.find(part => part.type === 'minute')?.value
+
+    if (hourPart === undefined || minutePart === undefined) return undefined
+
+    // Intl can emit "24" for midnight in some environments; normalize to 0.
+    const hours = Number(hourPart) % 24
+    const minutes = Number(minutePart)
+
+    if (!Number.isFinite(hours) || !Number.isFinite(minutes)) return undefined
+
+    return hours * 60 + minutes
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Determine whether the bot is currently within its configured active hours.
+ *
+ * The bot is always considered active unless ALL of timezone, active_start_time,
+ * and active_end_time are configured. Supports overnight windows where the start
+ * time is later than the end time (e.g. 17:00 -> 09:00).
+ *
+ * Any misconfiguration (unparseable times, invalid timezone) fails open so the
+ * bot stays available rather than silently going dark.
+ */
+export const isBotActive = (config: ActiveHoursConfig): boolean => {
+  const { timezone, active_start_time, active_end_time } = config
+
+  if (!timezone || !active_start_time || !active_end_time) {
+    return true
+  }
+
+  const start = timeStringToMinutes(active_start_time)
+  const end = timeStringToMinutes(active_end_time)
+  const now = currentMinutesInTimezone(timezone)
+
+  if (start === undefined || end === undefined || now === undefined) {
+    return true
+  }
+
+  // Equal start/end is treated as always active.
+  if (start === end) {
+    return true
+  }
+
+  if (start < end) {
+    // Same-day window, e.g. 09:00 -> 17:00.
+    return now >= start && now < end
+  }
+
+  // Overnight window, e.g. 17:00 -> 09:00.
+  return now >= start || now < end
+}

--- a/apps/backend/src/types/database.ts
+++ b/apps/backend/src/types/database.ts
@@ -81,30 +81,39 @@ export type Database = {
       }
       chat_configs: {
         Row: {
+          active_end_time: string | null
+          active_start_time: string | null
           company_id: string
           created_at: string
           pinecone_index_name: string | null
           sendgrid_template_id: string | null
           support_email: string | null
           system_prompt: string
+          timezone: string | null
           updated_at: string | null
         }
         Insert: {
+          active_end_time?: string | null
+          active_start_time?: string | null
           company_id: string
           created_at?: string
           pinecone_index_name?: string | null
           sendgrid_template_id?: string | null
           support_email?: string | null
           system_prompt: string
+          timezone?: string | null
           updated_at?: string | null
         }
         Update: {
+          active_end_time?: string | null
+          active_start_time?: string | null
           company_id?: string
           created_at?: string
           pinecone_index_name?: string | null
           sendgrid_template_id?: string | null
           support_email?: string | null
           system_prompt?: string
+          timezone?: string | null
           updated_at?: string | null
         }
         Relationships: [

--- a/apps/backend/supabase/migrations/20260604000000_add_active_hours_to_chat_configs.sql
+++ b/apps/backend/supabase/migrations/20260604000000_add_active_hours_to_chat_configs.sql
@@ -1,0 +1,14 @@
+-- Add configurable active hours to chat_configs.
+-- When timezone, active_start_time, and active_end_time are all set, the bot is
+-- only "live" within that daily window (evaluated in the configured timezone,
+-- with support for overnight windows like 17:00 -> 09:00). When any of these are
+-- NULL the bot is always active (backward compatible default).
+
+ALTER TABLE chat_configs
+    ADD COLUMN IF NOT EXISTS timezone TEXT,
+    ADD COLUMN IF NOT EXISTS active_start_time TIME,
+    ADD COLUMN IF NOT EXISTS active_end_time TIME;
+
+COMMENT ON COLUMN chat_configs.timezone IS 'IANA timezone (e.g. America/New_York) the active hours window is evaluated in';
+COMMENT ON COLUMN chat_configs.active_start_time IS 'Daily time the bot becomes active (inclusive). NULL means always active';
+COMMENT ON COLUMN chat_configs.active_end_time IS 'Daily time the bot becomes inactive (exclusive). NULL means always active';

--- a/apps/frontend/src/components/ChatWidget/ChatWidget.tsx
+++ b/apps/frontend/src/components/ChatWidget/ChatWidget.tsx
@@ -4,6 +4,7 @@ import { ChatWindow } from '../ChatWindow/ChatWindow'
 import { MobileChatModal } from '../MobileChatModal/MobileChatModal'
 import { useResizeObserver } from '../../hooks/useResizeObserver'
 import { useConfig } from '../../contexts/ConfigContext'
+import { useChatAvailability } from '../../hooks/useChatAvailability'
 import { useNavigationEvents } from '../../hooks/useNavigationEvents'
 import { cn } from '@/lib/utils'
 import type { ChatStatus } from '../../hooks/useChatPersistence'
@@ -14,6 +15,10 @@ export const ChatWidget = () => {
   const [chatStatus, setChatStatus] = useState<ChatStatus>('uninitialized')
 
   const { openOnLoad } = useConfig()
+
+  // Whether the bot is within its configured active hours. Hide the widget
+  // entirely when offline (or while we're still checking, to avoid a flash).
+  const availability = useChatAvailability()
 
   // Use the resize observer hook with a 150ms debounce delay
   // Fast enough to feel responsive, but not too frequent to cause performance issues
@@ -124,6 +129,12 @@ export const ChatWidget = () => {
     // Any additional logic needed when a new chat is created
     console.log('New chat created')
   }, [])
+
+  // Don't render anything outside the bot's active hours.
+  if (availability !== 'available') {
+    // eslint-disable-next-line no-null/no-null
+    return null
+  }
 
   return (
     <div 

--- a/apps/frontend/src/hooks/useChatAvailability.ts
+++ b/apps/frontend/src/hooks/useChatAvailability.ts
@@ -4,11 +4,16 @@ import { logger } from '../services/logger'
 
 export type AvailabilityStatus = 'checking' | 'available' | 'unavailable'
 
+// Cap how long we'll wait for the availability check before failing open. A
+// hung backend must never leave the widget stuck invisible for always-on bots.
+const AVAILABILITY_TIMEOUT_MS = 5000
+
 /**
  * Checks whether the bot is currently within its configured active hours.
  *
- * Fails open: if the availability check errors out for any reason, the bot is
- * treated as available so a transient backend issue never hides the widget.
+ * Fails open: if the availability check errors out, times out, or returns an
+ * error status, the bot is treated as available so a transient backend issue
+ * never hides the widget.
  */
 export function useChatAvailability(): AvailabilityStatus {
   const { chatConfig } = useConfig()
@@ -18,13 +23,19 @@ export function useChatAvailability(): AvailabilityStatus {
 
   useEffect(() => {
     let cancelled = false
+    const controller = new AbortController()
+    const timeoutId = setTimeout(
+      () => controller.abort(),
+      AVAILABILITY_TIMEOUT_MS
+    )
 
     const checkAvailability = async () => {
       try {
         const response = await fetch(
           `${apiBaseUrl}/chats/availability?companyId=${encodeURIComponent(
             companyId
-          )}`
+          )}`,
+          { signal: controller.signal }
         )
 
         if (!response.ok) {
@@ -39,13 +50,17 @@ export function useChatAvailability(): AvailabilityStatus {
           )
         }
       } catch (error) {
+        // Aborts from unmount/cleanup are expected — don't log or update state.
+        if (cancelled) return
         logger.warning(
           'Failed to check chat availability, defaulting to available',
           {
             error
           }
         )
-        if (!cancelled) setAvailabilityStatus('available')
+        setAvailabilityStatus('available')
+      } finally {
+        clearTimeout(timeoutId)
       }
     }
 
@@ -53,6 +68,8 @@ export function useChatAvailability(): AvailabilityStatus {
 
     return () => {
       cancelled = true
+      clearTimeout(timeoutId)
+      controller.abort()
     }
   }, [apiBaseUrl, companyId])
 

--- a/apps/frontend/src/hooks/useChatAvailability.ts
+++ b/apps/frontend/src/hooks/useChatAvailability.ts
@@ -1,0 +1,60 @@
+import { useState, useEffect } from 'react'
+import { useConfig } from '../contexts/ConfigContext'
+import { logger } from '../services/logger'
+
+export type AvailabilityStatus = 'checking' | 'available' | 'unavailable'
+
+/**
+ * Checks whether the bot is currently within its configured active hours.
+ *
+ * Fails open: if the availability check errors out for any reason, the bot is
+ * treated as available so a transient backend issue never hides the widget.
+ */
+export function useChatAvailability(): AvailabilityStatus {
+  const { chatConfig } = useConfig()
+  const { apiBaseUrl, companyId } = chatConfig
+  const [availabilityStatus, setAvailabilityStatus] =
+    useState<AvailabilityStatus>('checking')
+
+  useEffect(() => {
+    let cancelled = false
+
+    const checkAvailability = async () => {
+      try {
+        const response = await fetch(
+          `${apiBaseUrl}/chats/availability?companyId=${encodeURIComponent(
+            companyId
+          )}`
+        )
+
+        if (!response.ok) {
+          if (!cancelled) setAvailabilityStatus('available')
+          return
+        }
+
+        const data = await response.json()
+        if (!cancelled) {
+          setAvailabilityStatus(
+            data.available === false ? 'unavailable' : 'available'
+          )
+        }
+      } catch (error) {
+        logger.warning(
+          'Failed to check chat availability, defaulting to available',
+          {
+            error
+          }
+        )
+        if (!cancelled) setAvailabilityStatus('available')
+      }
+    }
+
+    checkAvailability()
+
+    return () => {
+      cancelled = true
+    }
+  }, [apiBaseUrl, companyId])
+
+  return availabilityStatus
+}


### PR DESCRIPTION
## Overview

Lets a bot be **live only during a configured daily time window** (a customer request: "have the chatbot active only on certain time slots, e.g. 5PM–9AM"). The window is set per company via timezone + start/end time and evaluated in the **business's own timezone**, with support for overnight windows (e.g. `17:00 → 09:00`). Outside the window the widget **hides entirely**.

## Changes

**Database** — `20260604000000_add_active_hours_to_chat_configs.sql`
- Adds three nullable columns to `chat_configs`: `timezone`, `active_start_time`, `active_end_time`.
- All unset ⇒ always active. **Backward compatible** — no existing company is affected.

**Backend**
- `chat-availability.ts`: `isBotActive(config)` computes current time in the configured timezone and compares against the window. Handles overnight wrap and **fails open** on any misconfiguration (bad tz / unparseable time) so the bot never silently goes dark.
- Public `GET /chats/availability?companyId=…` → `{ available: boolean }` (declared before `/:chatId` so it isn't captured as a chat id).
- Server-side `403` gate on `POST /chats/stream-ai-sdk` (defense-in-depth if the window flips mid-session).

**Frontend**
- `useChatAvailability` hook checks availability on load (fails open on error).
- `ChatWidget` renders nothing when offline.

## How to configure (e.g. 5PM–9AM Eastern)
Set on the company's `chat_configs` row:
```
timezone          = 'America/New_York'
active_start_time = '17:00'
active_end_time   = '09:00'
```

## Notes / follow-ups
- **No admin UI** — config is set directly in the DB (this repo has no settings screen). Self-serve config would be a separate build.
- **Run the migration** against Supabase environments before relying on the feature.
- Daily window only; `days_of_week` (e.g. weekdays) not included.

## Verification
- `tsc --noEmit` clean on backend + frontend.
- `eslint` clean on new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)