### PR TITLE
chore(backend): bump primary chat model gpt-5 → gpt-5.4

### DIFF
--- a/apps/backend/src/routes/chat-routes.ts
+++ b/apps/backend/src/routes/chat-routes.ts
@@ -630,7 +630,7 @@ router.post('/stream-ai-sdk', authenticateChatAccess, async (req: CustomRequest,
     }
 
     const result = streamText({
-      model: openai('gpt-5'),
+      model: openai('gpt-5.4'),
       system: systemPrompt,
       messages: modelMessages,
       tools: shouldEnableEmailTool ? {

--- a/apps/backend/src/services/openai-service.ts
+++ b/apps/backend/src/services/openai-service.ts
@@ -35,7 +35,7 @@ export type ChatSettings = {
 
 // Default settings to use if none are provided
 export const DEFAULT_SETTINGS: Pick<ChatSettings, 'model'> = {
-  model: 'gpt-5',
+  model: 'gpt-5.4',
 }
 
 /**


### PR DESCRIPTION
## Overview
Bumps the **primary chat-completion model** from `gpt-5` to `gpt-5.4` at the two main call sites.

## Changes
| File | Before → After |
|------|----------------|
| `services/openai-service.ts` (`DEFAULT_SETTINGS.model`) | `gpt-5` → `gpt-5.4` |
| `routes/chat-routes.ts` (`streamText` main response) | `gpt-5` → `gpt-5.4` |

## Intentionally left unchanged
- `gpt-5-nano` — query-enhancement helper (`chat-routes.ts`)
- `gpt-5-mini` — email detection (`email-detection.ts`)

These are deliberate cheaper models for auxiliary tasks. Say the word if you want them bumped too.

## ⚠️ Before merging — verify the model id
Please confirm `gpt-5.4` resolves on the OpenAI account/key used in prod. An invalid model id would error on **every** chat request, so this should be validated against the API before deploy.

## NSI
No NSI change here — NSI inherits this via its normal upstream sync (consistent with how active hours flowed in via #63 / NSI #2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)