### PR TITLE
chore: add changeset for widget active-hours feature

### DIFF
--- a/.changeset/widget-active-hours.md
+++ b/.changeset/widget-active-hours.md
@@ -1,0 +1,5 @@
+---
+"@dialogue-foundry/frontend": patch
+---
+
+Hide the chat widget outside the bot's configured active hours


### PR DESCRIPTION
## Why
#63 merged the active-hours **widget** change (`ChatWidget` hides outside configured hours + `useChatAvailability` hook) but **without a changeset**, so `@dialogue-foundry/frontend` never version-bumped and the published widget (0.4.64) doesn't include the feature.

## What
Adds the missing changeset (`@dialogue-foundry/frontend`, **patch** — matching the repo's 0.4.x convention).

`pnpm changeset status` confirms it bumps `@dialogue-foundry/frontend` at patch → next `pnpm version` + `pnpm publish-package` ships the widget (0.4.65) to S3.

## Release steps after merge
1. `pnpm version` (consumes the changeset, bumps to 0.4.65, updates CHANGELOG)
2. `pnpm publish-package` / `pnpm deploy-to-s3` to push the widget to S3

🤖 Generated with [Claude Code](https://claude.com/claude-code)