### PR TITLE
chore(release): widget 0.4.65 (active hours)

### DIFF
--- a/.changeset/widget-active-hours.md
+++ b/.changeset/widget-active-hours.md
@@ -1,5 +1,0 @@
----
-"@dialogue-foundry/frontend": patch
----
-
-Hide the chat widget outside the bot's configured active hours

--- a/apps/frontend/CHANGELOG.md
+++ b/apps/frontend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @dialogue-foundry/frontend
 
+## 0.4.65
+
+### Patch Changes
+
+- 2e6ef03: Hide the chat widget outside the bot's configured active hours
+
 ## 0.4.64
 
 ### Patch Changes

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dialogue-foundry/frontend",
   "private": true,
-  "version": "0.4.64",
+  "version": "0.4.65",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Overview
Release version bump produced by `pnpm changeset:version`. Consumes the active-hours changeset and bumps the widget.

## Changes
- `@dialogue-foundry/frontend`: **0.4.64 → 0.4.65**
- CHANGELOG: adds `0.4.65 — Hide the chat widget outside the bot's configured active hours`
- Removes the consumed `.changeset/widget-active-hours.md`

## After merge — publish the widget
```
pnpm publish-package   # or: pnpm deploy-to-s3 --package @dialogue-foundry/frontend --bucket <bucket>
```
This ships the active-hours widget (0.4.65) to S3 so embedding sites pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)