### PR TITLE
hotfix: revert chat model gpt-5.4 → gpt-5

### DIFF
--- a/apps/backend/src/routes/chat-routes.ts
+++ b/apps/backend/src/routes/chat-routes.ts
@@ -630,7 +630,7 @@ router.post('/stream-ai-sdk', authenticateChatAccess, async (req: CustomRequest,
     }
 
     const result = streamText({
-      model: openai('gpt-5.4'),
+      model: openai('gpt-5'),
       system: systemPrompt,
       messages: modelMessages,
       tools: shouldEnableEmailTool ? {

--- a/apps/backend/src/services/openai-service.ts
+++ b/apps/backend/src/services/openai-service.ts
@@ -35,7 +35,7 @@ export type ChatSettings = {
 
 // Default settings to use if none are provided
 export const DEFAULT_SETTINGS: Pick<ChatSettings, 'model'> = {
-  model: 'gpt-5.4',
+  model: 'gpt-5',
 }
 
 /**


### PR DESCRIPTION
## 🚨 Urgent — production chat sends are failing
`gpt-5.4` is not resolving as a valid model, so chat message sends fail. This reverts the two primary chat-completion call sites back to `gpt-5` (reverts #64).

## Changes
- `services/openai-service.ts` (`DEFAULT_SETTINGS.model`): `gpt-5.4` → `gpt-5`
- `routes/chat-routes.ts` (`streamText`): `gpt-5.4` → `gpt-5`

`gpt-5-nano` / `gpt-5-mini` were never changed and are untouched.

**Merge + deploy ASAP** to restore chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)