### PR TITLE
feat: configure active-hours window via embed config

### DIFF
--- a/.changeset/active-hours-embed-config.md
+++ b/.changeset/active-hours-embed-config.md
@@ -1,0 +1,5 @@
+---
+'@dialogue-foundry/frontend': patch
+---
+
+Allow the active-hours window (timezone, start, end) to be configured via the embed config, overriding the backend's configured hours and evaluating the window client-side.

--- a/.changeset/active-hours-embed-config.md
+++ b/.changeset/active-hours-embed-config.md
@@ -1,5 +1,0 @@
----
-'@dialogue-foundry/frontend': patch
----
-
-Allow the active-hours window (timezone, start, end) to be configured via the embed config, overriding the backend's configured hours and evaluating the window client-side.

--- a/apps/backend/src/routes/chat-routes.ts
+++ b/apps/backend/src/routes/chat-routes.ts
@@ -513,7 +513,7 @@ const requestUserEmailTool = tool({
 router.post('/stream-ai-sdk', authenticateChatAccess, async (req: CustomRequest, res) => {
 
   try {
-    const { id: chatId, messages, timezone } = req.body;
+    const { id: chatId, messages, timezone, activeHours } = req.body;
     const userId = req.user?.userId;
 
     if (!chatId || !userId) {
@@ -532,8 +532,16 @@ router.post('/stream-ai-sdk', authenticateChatAccess, async (req: CustomRequest,
       return res.status(400).json({ error: 'Company configuration not found' });
     }
 
-    // Reject messages received outside the bot's configured active hours.
-    if (!isBotActive(chatConfig)) {
+    // Reject messages received outside the bot's configured active hours. The
+    // embed config (sent in the request) overrides the DB-configured hours.
+    const hoursConfig = activeHours
+      ? {
+          timezone: activeHours.timezone,
+          active_start_time: activeHours.startTime,
+          active_end_time: activeHours.endTime
+        }
+      : chatConfig;
+    if (!isBotActive(hoursConfig)) {
       return res.status(403).json({ error: 'The chatbot is currently offline' });
     }
 

--- a/apps/frontend/CHANGELOG.md
+++ b/apps/frontend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @dialogue-foundry/frontend
 
+## 0.4.66
+
+### Patch Changes
+
+- fea57f5: Allow the active-hours window (timezone, start, end) to be configured via the embed config, overriding the backend's configured hours and evaluating the window client-side.
+
 ## 0.4.65
 
 ### Patch Changes

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dialogue-foundry/frontend",
   "private": true,
-  "version": "0.4.65",
+  "version": "0.4.66",
   "type": "module",
   "repository": {
     "type": "git",

--- a/apps/frontend/src/contexts/ConfigContext.tsx
+++ b/apps/frontend/src/contexts/ConfigContext.tsx
@@ -38,6 +38,15 @@ export interface DialogueFoundryConfig {
 
   openOnLoad?: 'all' | 'mobile-only' | 'desktop-only' | 'none'
 
+  // Active hours window. When set, the widget is only shown while the current
+  // time (in the given IANA timezone) is inside the window. Overrides the DB
+  // config; omit to fall back to the backend's configured hours.
+  activeHours?: {
+    timezone: string
+    startTime: string
+    endTime: string
+  }
+
   poweredBy?: {
     text?: string
     url?: string

--- a/apps/frontend/src/hooks/useChatAvailability.ts
+++ b/apps/frontend/src/hooks/useChatAvailability.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useConfig } from '../contexts/ConfigContext'
 import { logger } from '../services/logger'
+import { isBotActive } from '../utils/chat-availability'
 
 export type AvailabilityStatus = 'checking' | 'available' | 'unavailable'
 
@@ -11,17 +12,27 @@ const AVAILABILITY_TIMEOUT_MS = 5000
 /**
  * Checks whether the bot is currently within its configured active hours.
  *
+ * When `activeHours` is set in the embed config the window is evaluated
+ * client-side with no network call. Otherwise it falls back to the backend's
+ * DB-configured hours via the availability endpoint.
+ *
  * Fails open: if the availability check errors out, times out, or returns an
  * error status, the bot is treated as available so a transient backend issue
  * never hides the widget.
  */
 export function useChatAvailability(): AvailabilityStatus {
-  const { chatConfig } = useConfig()
+  const { chatConfig, activeHours } = useConfig()
   const { apiBaseUrl, companyId } = chatConfig
   const [availabilityStatus, setAvailabilityStatus] =
     useState<AvailabilityStatus>('checking')
 
   useEffect(() => {
+    // Embed config takes precedence: evaluate the window locally, no fetch.
+    if (activeHours) {
+      setAvailabilityStatus(isBotActive(activeHours) ? 'available' : 'unavailable')
+      return
+    }
+
     let cancelled = false
     const controller = new AbortController()
     const timeoutId = setTimeout(
@@ -71,7 +82,7 @@ export function useChatAvailability(): AvailabilityStatus {
       clearTimeout(timeoutId)
       controller.abort()
     }
-  }, [apiBaseUrl, companyId])
+  }, [apiBaseUrl, companyId, activeHours])
 
   return availabilityStatus
 }

--- a/apps/frontend/src/hooks/useChatPersistence.ts
+++ b/apps/frontend/src/hooks/useChatPersistence.ts
@@ -14,7 +14,7 @@ export function useChatPersistence() {
   const [initialMessages, setInitialMessages] = useState<UIMessage[]>([])
   const [streamError, setStreamError] = useState<string | null>(null)
 
-  const { chatConfig, welcomeMessage } = useConfig()
+  const { chatConfig, welcomeMessage, activeHours } = useConfig()
   const { currentLanguage } = useLanguage()
   const {apiBaseUrl} = chatConfig
 
@@ -55,11 +55,12 @@ export function useChatPersistence() {
             id: chatId || id,
             messages,
             timezone: userTimezone,
+            activeHours,
           },
         }
       }
     })
-  }, [apiBaseUrl, chatService, userTimezone, chatId])
+  }, [apiBaseUrl, chatService, userTimezone, chatId, activeHours])
 
   // Initialize useChat hook with dynamic transport
   const chat = useChat({

--- a/apps/frontend/src/utils/chat-availability.ts
+++ b/apps/frontend/src/utils/chat-availability.ts
@@ -1,0 +1,95 @@
+export type ActiveHours = {
+  timezone: string
+  startTime: string
+  endTime: string
+}
+
+/**
+ * Convert a "HH:MM" / "HH:MM:SS" time string into minutes since midnight.
+ * Returns undefined if the value can't be parsed.
+ */
+const timeStringToMinutes = (time: string): number | undefined => {
+  const match = /^(\d{1,2}):(\d{2})/.exec(time.trim())
+  if (!match) return undefined
+
+  const hours = Number(match[1])
+  const minutes = Number(match[2])
+
+  if (
+    !Number.isFinite(hours) ||
+    !Number.isFinite(minutes) ||
+    hours > 24 ||
+    minutes > 59
+  ) {
+    return undefined
+  }
+
+  return hours * 60 + minutes
+}
+
+/**
+ * Get the current minutes-since-midnight in the given IANA timezone.
+ * Falls back to undefined if the timezone is invalid.
+ */
+const currentMinutesInTimezone = (timezone: string): number | undefined => {
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      hour12: false,
+      hour: '2-digit',
+      minute: '2-digit'
+    }).formatToParts(new Date())
+
+    const hourPart = parts.find(part => part.type === 'hour')?.value
+    const minutePart = parts.find(part => part.type === 'minute')?.value
+
+    if (hourPart === undefined || minutePart === undefined) return undefined
+
+    // Intl can emit "24" for midnight in some environments; normalize to 0.
+    const hours = Number(hourPart) % 24
+    const minutes = Number(minutePart)
+
+    if (!Number.isFinite(hours) || !Number.isFinite(minutes)) return undefined
+
+    return hours * 60 + minutes
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Determine whether the bot is currently within its configured active hours.
+ *
+ * Mirrors the backend `isBotActive` logic so the widget and server agree.
+ * Supports overnight windows where the start time is later than the end time
+ * (e.g. 17:00 -> 09:00). Any misconfiguration (unparseable times, invalid
+ * timezone) fails open so the bot stays available rather than silently hiding.
+ */
+export const isBotActive = (activeHours: ActiveHours): boolean => {
+  const { timezone, startTime, endTime } = activeHours
+
+  if (!timezone || !startTime || !endTime) {
+    return true
+  }
+
+  const start = timeStringToMinutes(startTime)
+  const end = timeStringToMinutes(endTime)
+  const now = currentMinutesInTimezone(timezone)
+
+  if (start === undefined || end === undefined || now === undefined) {
+    return true
+  }
+
+  // Equal start/end is treated as always active.
+  if (start === end) {
+    return true
+  }
+
+  if (start < end) {
+    // Same-day window, e.g. 09:00 -> 17:00.
+    return now >= start && now < end
+  }
+
+  // Overnight window, e.g. 17:00 -> 09:00.
+  return now >= start || now < end
+}


### PR DESCRIPTION
## Context

The active-hours feature (hide the chat widget outside a configured time window) currently stores the window in the **DB** (`chat_configs.timezone`, `active_start_time`, `active_end_time`). The customer (gefonline / NSI) wants to set these hours themselves in the **embed JSON config** — the same `<script id="dialogue-foundry-config">` block they already use for `title`, `styles`, `openOnLoad`, etc. — instead of needing a DB write.

## Approach

- **Frontend overrides DB**: an `activeHours` block in the embed JSON wins; the DB columns remain as a fallback. `/availability` endpoint and the backend gate are retained.
- **Client-side evaluation**: when `activeHours` is present, the widget evaluates the window locally (no `/availability` round-trip — also avoids the CDN-cache/latency seen on gefonline). When absent, it falls back to the existing DB path.

## Changes

**Frontend (`apps/frontend`)**
- `contexts/ConfigContext.tsx` — add optional `activeHours: { timezone, startTime, endTime }` to `DialogueFoundryConfig`.
- `utils/chat-availability.ts` (**new**) — `isBotActive({ timezone, startTime, endTime })`, ported from the backend logic (overnight windows, fail-open).
- `hooks/useChatAvailability.ts` — evaluate the window client-side when `activeHours` is set; else fall back to `GET /availability`.
- `hooks/useChatPersistence.ts` — send `activeHours` in the `/stream-ai-sdk` request body.

**Backend (`apps/backend`)**
- `routes/chat-routes.ts` — `/stream-ai-sdk` gate honors request-provided `activeHours` (mapped to the DB column shape), else falls back to the DB `chatConfig`. `isBotActive` and `GET /availability` unchanged.

**Changeset**: `.changeset/active-hours-embed-config.md` (required for the widget to ship).

## Embed config usage

```html
<script id="dialogue-foundry-config" type="application/json">
{
  "chatConfig": { "...": "..." },
  "activeHours": {
    "timezone": "America/New_York",
    "startTime": "17:00",
    "endTime": "09:00"
  }
}
</script>
```

## Notes
- The request-provided window is client-trusted — acceptable here since it mirrors the already-client-trusted `timezone` field, and the DB columns remain authoritative when the client sends nothing.
- **NSI**: only the backend gate change needs to reach NSI, via the upstream-sync merge (shared widget needs no fork edit).

## Verification
- `pnpm --filter @dialogue-foundry/frontend typecheck` — clean
- `pnpm --filter @dialogue-foundry/frontend build` — clean
- `apps/backend` `tsc` build — clean
- `pnpm changeset status` — lists the `@dialogue-foundry/frontend` patch bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)