### PR TITLE
fix(deploy): Cache-Control on widget loader + redeploy 0.4.67

### DIFF
--- a/apps/frontend/CHANGELOG.md
+++ b/apps/frontend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @dialogue-foundry/frontend
 
+## 0.4.67
+
+### Patch Changes
+
+- Re-deploy the widget loader so it ships with a `no-cache` header, ensuring future releases reach users promptly instead of being held back by browser caching.
+
 ## 0.4.66
 
 ### Patch Changes

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dialogue-foundry/frontend",
   "private": true,
-  "version": "0.4.66",
+  "version": "0.4.67",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/deploy-s3/src/version-based-deploy.ts
+++ b/packages/deploy-s3/src/version-based-deploy.ts
@@ -248,9 +248,10 @@ async function main() {
         Bucket: options.bucket,
         Key: versionTxtKey,
         Body: currentVersion,
-        ContentType: 'text/plain'
+        ContentType: 'text/plain',
+        CacheControl: 'no-cache'
       }).promise();
-      
+
       console.log(chalk.green(`✅ Created new folder at ${versionPath}`));
     } else if (shouldUpdateMajorMinor) {
       console.log(chalk.blue(`\n📤 Updating existing major.minor folder: s3://${options.bucket}/${versionPath}/`));
@@ -261,9 +262,10 @@ async function main() {
         Bucket: options.bucket,
         Key: versionTxtKey,
         Body: currentVersion,
-        ContentType: 'text/plain'
+        ContentType: 'text/plain',
+        CacheControl: 'no-cache'
       }).promise();
-      
+
       console.log(chalk.green(`✅ Updated existing folder at ${versionPath} to patch version ${patch}`));
     }
 
@@ -276,9 +278,10 @@ async function main() {
         Bucket: options.bucket,
         Key: latestVersionTxtKey,
         Body: currentVersion,
-        ContentType: 'text/plain'
+        ContentType: 'text/plain',
+        CacheControl: 'no-cache'
       }).promise();
-      
+
       console.log(chalk.green(`✅ Updated latest to ${currentVersion}`));
     }
 
@@ -325,7 +328,8 @@ async function deployToS3(s3: S3, bucket: string, sourcePath: string, s3Path: st
       Bucket: bucket,
       Key: key,
       Body: fs.readFileSync(filePath),
-      ContentType: getContentType(filePath)
+      ContentType: getContentType(filePath),
+      CacheControl: getCacheControl(filePath)
     };
     
     try {
@@ -334,6 +338,24 @@ async function deployToS3(s3: S3, bucket: string, sourcePath: string, s3Path: st
       throw new Error(`Failed to upload ${file}: ${error.message}`);
     }
   }
+}
+
+// Get the Cache-Control header for a file.
+//
+// The widget loader is embedded at a stable URL (e.g. `0.4/index.js`), so it
+// must be revalidated on every load or browsers heuristically cache it and
+// users keep running an old release. `version.txt` and any HTML entry are
+// markers that change every release, so they revalidate too. Everything else
+// the build emits is content-hashed and safe to cache indefinitely.
+function getCacheControl(filePath: string): string {
+  const base = path.basename(filePath).toLowerCase();
+  const ext = path.extname(filePath).toLowerCase();
+
+  if (base === 'index.js' || base === 'version.txt' || ext === '.html') {
+    return 'no-cache';
+  }
+
+  return 'public, max-age=31536000, immutable';
 }
 
 // Get content type based on file extension


### PR DESCRIPTION
## Problem

The S3 uploader (`packages/deploy-s3`) set `ContentType` but **no `Cache-Control`**, so browsers heuristically cached the stable widget loader URL (`0.4/index.js`). After a release, users kept running the old widget until their browser's heuristic cache expired — this is the stale-bundle behavior seen on gefonline.

## Fix

In `deployToS3`, every upload now sets `Cache-Control`:
- **`index.js`, `version.txt`, `.html`** → `no-cache` — revalidated on every load (unchanged → cheap `304` via ETag), so releases propagate immediately.
- **everything else** (future content-hashed assets) → `public, max-age=31536000, immutable`.

The three `version.txt` uploads also get `no-cache`.

## Why the version bump

The embedded loader lives at `0.4/index.js`, which the deploy only re-uploads when the **patch version changes**. So this PR also bumps the widget `0.4.66 → 0.4.67` (changeset consumed) so merging re-deploys `0.4/index.js` **carrying the new `no-cache` header now**, rather than waiting for the next feature release.

CloudFront is already invalidated on each publish; this closes the remaining browser-cache gap.

## Files
- `packages/deploy-s3/src/version-based-deploy.ts` — `getCacheControl()` + apply to uploads
- `apps/frontend/package.json`, `apps/frontend/CHANGELOG.md` — `0.4.67`

## Verification
- `packages/deploy-s3` `tsc` build clean; `CacheControl` present in compiled `dist`.
- On next publish, `curl -I https://djwdzs5n3r4m2.cloudfront.net/0.4/index.js` should show `cache-control: no-cache`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)