### PR TITLE
Add Upstash Vector as swappable read provider (VECTOR_PROVIDER toggle)

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -9,8 +9,16 @@ SUPABASE_SERVICE_ROLE_KEY=<your-supabase-service-role-key>
 # OpenAI Configuration
 OPENAI_API_KEY=<your-openai-api-key>
 
-# Pinecone Configuration
+# Vector store provider: 'pinecone' (default) or 'upstash'.
+# Flip to 'upstash' to switch all companies; flip back to roll back instantly.
+VECTOR_PROVIDER=pinecone
+
+# Pinecone Configuration (used when VECTOR_PROVIDER=pinecone)
 PINECONE_API_KEY=<your-pinecone-api-key>
+
+# Upstash Vector Configuration (used when VECTOR_PROVIDER=upstash)
+UPSTASH_VECTOR_REST_URL=<your-upstash-vector-rest-url>
+UPSTASH_VECTOR_REST_TOKEN=<your-upstash-vector-rest-token>
 
 # Authentication Configuration
 JWT_SECRET=<your-jwt-secret-key>

--- a/apps/backend/.env.production.example
+++ b/apps/backend/.env.production.example
@@ -19,6 +19,16 @@ NODE_ENV=production
 # OpenAI API Key (KEEP SECRET)
 OPENAI_API_KEY=your-openai-api-key
 
+# Vector store provider: 'pinecone' (default) or 'upstash'
+VECTOR_PROVIDER=pinecone
+
+# Pinecone (KEEP SECRET) — used when VECTOR_PROVIDER=pinecone
+PINECONE_API_KEY=your-pinecone-api-key
+
+# Upstash Vector (KEEP SECRET) — used when VECTOR_PROVIDER=upstash
+UPSTASH_VECTOR_REST_URL=your-upstash-vector-rest-url
+UPSTASH_VECTOR_REST_TOKEN=your-upstash-vector-rest-token
+
 # Server Configuration
 PORT=3000
 ALLOWED_ORIGINS=https://your-website.com,https://www.your-website.com

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -48,6 +48,7 @@
     "@types/jsonwebtoken": "^9.0.9",
     "@types/node": "^20.17.24",
     "@types/uuid": "^9.0.8",
+    "@upstash/vector": "^1.2.3",
     "ai": "^5.0.28",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",

--- a/apps/backend/src/routes/chat-routes.ts
+++ b/apps/backend/src/routes/chat-routes.ts
@@ -29,7 +29,7 @@ import { getChatConfigByCompanyId } from '../db/chat-configs'
 import {
   retrieveDocuments,
   formatDocumentsAsContext
-} from '../services/pinecone-service'
+} from '../services/vector-service'
 
 import { logger } from '../lib/logger'
 import type { CustomRequest } from '../middleware/auth-middleware'

--- a/apps/backend/src/services/pinecone-service.ts
+++ b/apps/backend/src/services/pinecone-service.ts
@@ -4,21 +4,19 @@ import { logger } from '../lib/logger'
 
 dotenv.config()
 
-// Check for API key in environment variables
-const pineconeApiKey = process.env.PINECONE_API_KEY
-if (!pineconeApiKey) {
-  console.error('PINECONE_API_KEY is not set in environment variables')
-  process.exit(1)
-}
+// Lazily initialized so importing this module under VECTOR_PROVIDER=upstash
+// doesn't hard-exit when PINECONE_API_KEY is absent.
+let pinecone: Pinecone | undefined
 
-// Initialize Pinecone client
-const pinecone = new Pinecone({
-  apiKey: pineconeApiKey
-})
-
-type RetrievedDocument = {
-  text: string
-  url?: string | undefined
+const getPinecone = (): Pinecone => {
+  if (!pinecone) {
+    const pineconeApiKey = process.env.PINECONE_API_KEY
+    if (!pineconeApiKey) {
+      throw new Error('PINECONE_API_KEY is not set in environment variables')
+    }
+    pinecone = new Pinecone({ apiKey: pineconeApiKey })
+  }
+  return pinecone
 }
 
 /**
@@ -37,7 +35,7 @@ export const retrieveDocuments = async (
 ) => {
   try {
     // Get the index directly without caching
-    const index = pinecone.index(indexName).namespace('')
+    const index = getPinecone().index(indexName).namespace('')
 
     // Query the Pinecone index with the text query feature
     // This uses serverless Pinecone with auto-embedding
@@ -61,32 +59,11 @@ export const retrieveDocuments = async (
           text: fields.chunk_text,
         }
       })
-      .filter((doc) => doc !== undefined)
+      .filter((doc): doc is { text: string } => doc !== undefined)
 
     return documents
   } catch (error) {
     logger.error('Error retrieving documents from Pinecone:', error)
     return []
   }
-}
-
-/**
- * Formats retrieved documents as context for the LLM
- * @param documents The retrieved documents with URLs
- * @returns Formatted context string to append to the LLM prompt
- */
-export const formatDocumentsAsContext = (documents: RetrievedDocument[]) => {
-  if (!documents.length) return ''
-
-  // Create a formatted context string from the documents
-  const contextParts = documents.map((doc, index) => {
-    return `
-    [Document ${index + 1}]
-
-    ${doc.text}`
-  })
-
-  return `Relevant information from the knowledge base. Use the following information only to answer the user's question::
-  
-  ${contextParts.join('\n\n')}`
 }

--- a/apps/backend/src/services/upstash-service.ts
+++ b/apps/backend/src/services/upstash-service.ts
@@ -1,0 +1,72 @@
+import { Index } from '@upstash/vector'
+import dotenv from 'dotenv'
+import { logger } from '../lib/logger'
+
+dotenv.config()
+
+// Lazily initialized so importing this module under VECTOR_PROVIDER=pinecone
+// doesn't require Upstash credentials to be set.
+let index: Index | undefined
+
+const getIndex = (): Index => {
+  if (!index) {
+    const url = process.env.UPSTASH_VECTOR_REST_URL
+    const token = process.env.UPSTASH_VECTOR_REST_TOKEN
+    if (!url || !token) {
+      throw new Error(
+        'UPSTASH_VECTOR_REST_URL and UPSTASH_VECTOR_REST_TOKEN must be set in environment variables'
+      )
+    }
+    index = new Index({ url, token })
+  }
+  return index
+}
+
+/**
+ * Retrieves documents from the company's Upstash namespace based on the query.
+ * Uses Upstash's built-in embedding model (raw text via the `data` field), so
+ * the namespace mirrors the company's former Pinecone index name.
+ * @param namespace The company's namespace (the chat_configs.pinecone_index_name value)
+ * @param query The user's query to find similar documents
+ * @param topK Number of documents to retrieve (default: 10)
+ * @returns Array of retrieved documents
+ */
+export const retrieveDocuments = async (
+  namespace: string,
+  query: string,
+  topK: number = 10
+) => {
+  try {
+    const results = await getIndex().query(
+      {
+        data: query,
+        topK,
+        includeMetadata: true,
+        includeData: true
+      },
+      { namespace }
+    )
+
+    const documents = results
+      .map(hit => {
+        const text = typeof hit.data === 'string' ? hit.data : undefined
+        if (!text) return undefined
+
+        const url =
+          hit.metadata && typeof hit.metadata.url === 'string'
+            ? hit.metadata.url
+            : undefined
+
+        return { text, url }
+      })
+      .filter(
+        (doc): doc is { text: string; url: string | undefined } =>
+          doc !== undefined
+      )
+
+    return documents
+  } catch (error) {
+    logger.error('Error retrieving documents from Upstash:', error)
+    return []
+  }
+}

--- a/apps/backend/src/services/vector-service.ts
+++ b/apps/backend/src/services/vector-service.ts
@@ -1,0 +1,52 @@
+import { retrieveDocuments as pineconeRetrieveDocuments } from './pinecone-service'
+import { retrieveDocuments as upstashRetrieveDocuments } from './upstash-service'
+
+/**
+ * Provider-agnostic vector retrieval facade.
+ *
+ * Dispatches to Pinecone or Upstash based on the VECTOR_PROVIDER env var
+ * (default 'pinecone'). During the migration this lets us flip all companies to
+ * Upstash with one env var and roll back instantly. The first argument is the
+ * chat_configs.pinecone_index_name value — a Pinecone index name for Pinecone,
+ * and the per-company namespace for Upstash.
+ */
+
+type RetrievedDocument = {
+  text: string
+  url?: string | undefined
+}
+
+const vectorProvider = process.env.VECTOR_PROVIDER || 'pinecone'
+
+export const retrieveDocuments = async (
+  indexNameOrNamespace: string,
+  query: string,
+  topK: number = 10,
+  filter?: Record<string, unknown>
+): Promise<RetrievedDocument[]> => {
+  if (vectorProvider === 'upstash') {
+    return upstashRetrieveDocuments(indexNameOrNamespace, query, topK)
+  }
+
+  return pineconeRetrieveDocuments(indexNameOrNamespace, query, topK, filter)
+}
+
+/**
+ * Formats retrieved documents as context for the LLM. Provider-agnostic.
+ * @param documents The retrieved documents
+ * @returns Formatted context string to append to the LLM prompt
+ */
+export const formatDocumentsAsContext = (documents: RetrievedDocument[]) => {
+  if (!documents.length) return ''
+
+  const contextParts = documents.map((doc, index) => {
+    return `
+    [Document ${index + 1}]
+
+    ${doc.text}`
+  })
+
+  return `Relevant information from the knowledge base. Use the following information only to answer the user's question::
+
+  ${contextParts.join('\n\n')}`
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@types/uuid':
         specifier: ^9.0.8
         version: 9.0.8
+      '@upstash/vector':
+        specifier: ^1.2.3
+        version: 1.2.3
       ai:
         specifier: ^5.0.28
         version: 5.0.28(zod@4.1.5)
@@ -1788,6 +1791,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-darwin-arm64@1.3.3':
     resolution: {integrity: sha512-EpRILdWr3/xDa/7MoyfO7JuBIJqpBMphtu4+80BK1bRfFcniVT74h3Z7q1+WOc92FuIAYatB1vn9TJR67sORGw==}
@@ -1863,6 +1867,9 @@ packages:
     resolution: {integrity: sha512-GraLbYqOJcmW1qY3osB+2YIiD62nVf2/bVLHZmrb4t/YSUwE03l7TwcDJl08T/Tm3SVhepX8RQkpzWbag/Sb4w==}
     cpu: [x64]
     os: [win32]
+
+  '@upstash/vector@1.2.3':
+    resolution: {integrity: sha512-yXsWKeuHNYyH72BcSZd3bV5ZD5MybAoTvKxkMaeV2UzuGfNzbHBVh5eO+ysTWTFAf8I9XcOueF4tZfAGjCa4Iw==}
 
   '@vitejs/plugin-react@4.3.4':
     resolution: {integrity: sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug==}
@@ -2041,6 +2048,7 @@ packages:
   aws-sdk@2.1692.0:
     resolution: {integrity: sha512-x511uiJ/57FIsbgUe5csJ13k3uzu25uWQE+XqfBis/sB0SFoiElJWXRkgEAUh0U6n40eT3ay5Ue4oPkRMu1LYw==}
     engines: {node: '>= 10.0.0'}
+    deprecated: The AWS SDK for JavaScript (v2) has reached end-of-support, and no longer receives updates. Please migrate your code to use AWS SDK for JavaScript (v3). More info https://a.co/cUPnyil
 
   axios@1.8.4:
     resolution: {integrity: sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==}
@@ -2978,11 +2986,12 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-modules@1.0.0:
     resolution: {integrity: sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==}
@@ -4580,6 +4589,7 @@ packages:
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -4689,6 +4699,7 @@ packages:
 
   tsc@2.0.4:
     resolution: {integrity: sha512-fzoSieZI5KKJVBYGvwbVZs/J5za84f2lSTLPYf6AGiIf43tZ3GNrI1QzTLcjtyDDP4aLxd46RTZq1nQxe7+k5Q==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     hasBin: true
 
   tsconfig-paths@3.15.0:
@@ -4867,10 +4878,12 @@ packages:
 
   uuid@8.0.0:
     resolution: {integrity: sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -6723,6 +6736,8 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.3.3':
     optional: true
+
+  '@upstash/vector@1.2.3': {}
 
   '@vitejs/plugin-react@4.3.4(vite@6.2.5(@types/node@20.17.30)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1))':
     dependencies:


### PR DESCRIPTION
## Summary
- Adds `upstash-service.ts` to query Upstash Vector using hosted `BAAI/bge-large-en-v1.5` embeddings (same "send raw text" pattern as current Pinecone integrated inference)
- Introduces `vector-service.ts` as a provider dispatcher — flip `VECTOR_PROVIDER=upstash` to cut over all companies, flip back to `pinecone` for instant rollback
- Refactors `pinecone-service.ts` from top-level `process.exit` to lazy-init so it's safe to import under `VECTOR_PROVIDER=upstash` without Pinecone creds

**Part of the Pinecone → Upstash migration** to eliminate the $50/mo Standard plan minimum. The web-crawler PR handles the write side (dual-write); this PR handles the read side.

## New files
- `services/upstash-service.ts` — queries Upstash by namespace (namespace = `chat_configs.pinecone_index_name`)
- `services/vector-service.ts` — `VECTOR_PROVIDER`-gated dispatcher + `formatDocumentsAsContext`

## Changed files
- `services/pinecone-service.ts` — lazy-init client (no `process.exit` at import time)
- `routes/chat-routes.ts` — import switched from `pinecone-service` to `vector-service` (both call sites)
- `package.json` / `pnpm-lock.yaml` — added `@upstash/vector`
- `.env.example`, `.env.production.example` — documented `VECTOR_PROVIDER`, `UPSTASH_VECTOR_REST_URL`, `UPSTASH_VECTOR_REST_TOKEN`

## Test plan
- [ ] `pnpm build` passes (verified locally ✅)
- [ ] With `VECTOR_PROVIDER=pinecone` (default) — chat RAG works as before
- [ ] After backfilling Upstash (web-crawler PR): set `VECTOR_PROVIDER=upstash`, confirm RAG returns equivalent results
- [ ] Rollback: set `VECTOR_PROVIDER=pinecone`, confirm instant recovery
- [ ] With `VECTOR_PROVIDER=upstash` and `PINECONE_API_KEY` unset — server starts without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)