### PR TITLE
chore: upgrade models to gpt-5.5 and gpt-5.4-mini

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -56,7 +56,7 @@
     "express-rate-limit": "^7.5.0",
     "jsonwebtoken": "^9.0.2",
     "node-cache": "^5.1.2",
-    "openai": "^6.9.0",
+    "openai": "^6.42.0",
     "tsc": "^2.0.4",
     "typescript": "^5.3.3",
     "uuid": "^9.0.1",

--- a/apps/backend/src/routes/chat-routes.ts
+++ b/apps/backend/src/routes/chat-routes.ts
@@ -100,7 +100,7 @@ Example:
 Return ONLY the rewritten query, nothing else.`
 
     const { text } = await generateText({
-      model: openai('gpt-5-nano'),
+      model: openai('gpt-5.4-mini'),
       prompt,
       temperature: 0,
       providerOptions: {
@@ -638,7 +638,7 @@ router.post('/stream-ai-sdk', authenticateChatAccess, async (req: CustomRequest,
     }
 
     const result = streamText({
-      model: openai('gpt-5'),
+      model: openai('gpt-5.5'),
       system: systemPrompt,
       messages: modelMessages,
       tools: shouldEnableEmailTool ? {

--- a/apps/backend/src/services/openai-service.ts
+++ b/apps/backend/src/services/openai-service.ts
@@ -35,7 +35,7 @@ export type ChatSettings = {
 
 // Default settings to use if none are provided
 export const DEFAULT_SETTINGS: Pick<ChatSettings, 'model'> = {
-  model: 'gpt-5',
+  model: 'gpt-5.5',
 }
 
 /**

--- a/apps/backend/src/services/utils/email-detection.ts
+++ b/apps/backend/src/services/utils/email-detection.ts
@@ -24,7 +24,7 @@ const openai = new OpenAI({
 })
 
 // Email detection model settings
-const EMAIL_DETECTION_MODEL = 'gpt-5-mini'
+const EMAIL_DETECTION_MODEL = 'gpt-5.4-mini'
 
 // Tool definition for the email detection LLM
 const requestUserEmailTool = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,8 +87,8 @@ importers:
         specifier: ^5.1.2
         version: 5.1.2
       openai:
-        specifier: ^6.9.0
-        version: 6.9.0(ws@8.18.1)(zod@4.1.5)
+        specifier: ^6.42.0
+        version: 6.42.0(ws@8.18.1)(zod@4.1.5)
       tsc:
         specifier: ^2.0.4
         version: 2.0.4
@@ -3925,9 +3925,8 @@ packages:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
-  openai@6.9.0:
-    resolution: {integrity: sha512-n2sJRYmM+xfJ0l3OfH8eNnIyv3nQY7L08gZQu3dw6wSdfPtKAk92L83M2NIP5SS8Cl/bsBBG3yKzEOjkx0O+7A==}
-    hasBin: true
+  openai@6.42.0:
+    resolution: {integrity: sha512-1WFEt/uXMXOLhYRNkgJWo08Y2YNvNwpVU72K7ibrWgWpNOXd4VojXLbe6SQ4bLiUQ3Y8jz4IiyVkylJCL1DtZg==}
     peerDependencies:
       ws: ^8.18.0
       zod: ^3.25 || ^4.0
@@ -9155,7 +9154,7 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@6.9.0(ws@8.18.1)(zod@4.1.5):
+  openai@6.42.0(ws@8.18.1)(zod@4.1.5):
     optionalDependencies:
       ws: 8.18.1
       zod: 4.1.5


### PR DESCRIPTION
## Summary

- Replace `gpt-5` with `gpt-5.5` for the main chat endpoint and default model fallback
- Replace `gpt-5-nano` (query enhancement) and `gpt-5-mini` (email detection) with `gpt-5.4-mini`
- Bump `openai` package minimum from `^6.9.0` to `^6.42.0` to ensure latest SDK is used

## No API parameter changes required
`reasoning.effort`, `text.verbosity`, `service_tier`, and the Responses API request shape are all unchanged for the new models.

## Test plan
- [ ] Verify main chat streaming works with `gpt-5.5`
- [ ] Verify query enhancement works with `gpt-5.4-mini`
- [ ] Verify email detection triggers correctly with `gpt-5.4-mini`

🤖 Generated with [Claude Code](https://claude.com/claude-code)