### PR TITLE
fix: replace unsupported reasoning effort 'minimal' with 'low'

### DIFF
--- a/apps/backend/src/routes/chat-routes.ts
+++ b/apps/backend/src/routes/chat-routes.ts
@@ -105,7 +105,7 @@ Return ONLY the rewritten query, nothing else.`
       temperature: 0,
       providerOptions: {
         openai: {
-          reasoningEffort: "minimal",
+          reasoningEffort: "low",
         }
       }
     })
@@ -668,7 +668,7 @@ router.post('/stream-ai-sdk', authenticateChatAccess, async (req: CustomRequest,
       },
       providerOptions: {
         openai: {
-          reasoningEffort: "minimal",
+          reasoningEffort: "low",
           textVerbosity: "low",
           serviceTier: "priority"
         }

--- a/apps/backend/src/services/openai-service.ts
+++ b/apps/backend/src/services/openai-service.ts
@@ -101,7 +101,7 @@ export const generateStreamingChatCompletion = async (
       input: limitedMessages,
       instructions: systemPromptWithCurrentDate,
       reasoning: {
-        effort: "minimal"
+        effort: "low"
       },
       stream: true,
       text: {

--- a/apps/backend/src/services/utils/email-detection.ts
+++ b/apps/backend/src/services/utils/email-detection.ts
@@ -176,7 +176,7 @@ Do NOT call the function if:
         }
       ],
       reasoning: {
-        effort: "minimal"
+        effort: "low"
       },
       service_tier: "priority",
       tools: [requestUserEmailTool]


### PR DESCRIPTION
## Summary

gpt-5.5 and gpt-5.4-mini no longer support `'minimal'` as a `reasoning.effort` value. Supported values are: `none`, `low`, `medium`, `high`, `xhigh`.

Replaced all 4 occurrences of `"minimal"` with `"low"` across:
- `openai-service.ts` — main chat streaming
- `chat-routes.ts` — query enhancement (gpt-5.4-mini) and main stream endpoint (gpt-5.5)
- `email-detection.ts` — email detection (gpt-5.4-mini)

## Test plan
- [ ] Verify chat responses stream without 400 errors
- [ ] Verify email detection functions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)