### PR TITLE
fix: hide native scrollbar on Radix ScrollArea viewports

### DIFF
--- a/apps/frontend/CHANGELOG.md
+++ b/apps/frontend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @dialogue-foundry/frontend
 
+## 0.4.68
+
+### Patch Changes
+
+- Fix double scrollbar on the horizontally-scrollable suggestions list, where the native browser scrollbar and the custom Radix scrollbar were both rendering due to a CSS specificity conflict
+
 ## 0.4.67
 
 ### Patch Changes

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dialogue-foundry/frontend",
   "private": true,
-  "version": "0.4.67",
+  "version": "0.4.68",
   "type": "module",
   "repository": {
     "type": "git",

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -207,34 +207,43 @@
 
 /* Custom scrollbar styling for all devices */
 /* Webkit browsers (Chrome, Safari, Edge) */
-#dialogue-foundry-app ::-webkit-scrollbar {
+/* Excludes Radix ScrollArea viewports, which render their own custom thumb and must keep the native scrollbar hidden */
+#dialogue-foundry-app *:not([data-radix-scroll-area-viewport])::-webkit-scrollbar {
   width: 8px;
   height: 8px;
 }
 
-#dialogue-foundry-app ::-webkit-scrollbar-track {
+#dialogue-foundry-app *:not([data-radix-scroll-area-viewport])::-webkit-scrollbar-track {
   background: var(--df-color-background);
   border-radius: 4px;
 }
 
-#dialogue-foundry-app ::-webkit-scrollbar-thumb {
+#dialogue-foundry-app *:not([data-radix-scroll-area-viewport])::-webkit-scrollbar-thumb {
   background: var(--df-color-primary);
   border-radius: 4px;
   border: 1px solid var(--df-color-gray-200);
 }
 
-#dialogue-foundry-app ::-webkit-scrollbar-thumb:hover {
+#dialogue-foundry-app *:not([data-radix-scroll-area-viewport])::-webkit-scrollbar-thumb:hover {
   background: color-mix(in srgb, var(--df-color-primary) 80%, black);
 }
 
-#dialogue-foundry-app ::-webkit-scrollbar-thumb:active {
+#dialogue-foundry-app *:not([data-radix-scroll-area-viewport])::-webkit-scrollbar-thumb:active {
   background: color-mix(in srgb, var(--df-color-primary) 70%, black);
+}
+
+[data-radix-scroll-area-viewport]::-webkit-scrollbar {
+  display: none;
 }
 
 /* Firefox scrollbar styling */
 #dialogue-foundry-app {
   scrollbar-width: thin;
   scrollbar-color: var(--df-color-primary) var(--df-color-background);
+}
+
+[data-radix-scroll-area-viewport] {
+  scrollbar-width: none;
 }
 
 /* Custom animations */


### PR DESCRIPTION
## Summary
- Global `#dialogue-foundry-app` scrollbar CSS was overriding Radix's own rule that hides the native scrollbar on its `ScrollArea` viewport, causing both the native and custom scrollbars to show on the horizontally-scrollable suggestions list.
- Scoped the global scrollbar styling to exclude `[data-radix-scroll-area-viewport]` and added an explicit override so the native scrollbar stays hidden wherever Radix's custom `ScrollBar` is used.
- Includes changeset-generated version bump (`@dialogue-foundry/frontend` 0.4.67 → 0.4.68) and changelog entry.

## Test plan
- [x] `pnpm run build` passes
- [ ] Manually verify the suggestions scroller shows only the custom scrollbar in Chrome/Safari and Firefox

🤖 Generated with [Claude Code](https://claude.com/claude-code)