### PR TITLE
feat: rebuild demo-setup with self-hosted scraping and Claude generation

### DIFF
--- a/apps/demo-setup/.dockerignore
+++ b/apps/demo-setup/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env
+*.log

--- a/apps/demo-setup/.env.example
+++ b/apps/demo-setup/.env.example
@@ -1,0 +1,49 @@
+# ---- Server ----
+PORT=4000
+# Comma-separated bearer tokens accepted on POST /demos. Leave empty to disable auth.
+DEMO_SETUP_API_KEYS=
+
+# ---- Anthropic ----
+ANTHROPIC_API_KEY=
+# Models used for the two consolidated LLM steps
+MODEL_ANALYSIS=claude-haiku-4-5
+MODEL_BRAND=claude-haiku-4-5
+
+# ---- OpenAI (background crawl only) ----
+# The deep crawl (orchestrator.py) still uses OpenAI internally for content
+# filtering/summarization — unrelated to this service's own Claude calls above.
+CRAWLER_OPENAI_API_KEY=
+
+# ---- Supabase (target project switches on isProd) ----
+SUPABASE_PROD_URL=
+SUPABASE_PROD_SERVICE_ROLE_KEY=
+SUPABASE_TEST_URL=
+SUPABASE_TEST_SERVICE_ROLE_KEY=
+
+# ---- Upstash Vector (shared index; namespace is per-company) ----
+UPSTASH_VECTOR_REST_URL=
+UPSTASH_VECTOR_REST_TOKEN=
+
+# ---- AWS S3 (demo hosting bucket) ----
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=us-east-1
+DEMO_S3_BUCKET=demo.untap-ai.com
+DEMO_BASE_URL=https://demo.untap-ai.com
+
+# ---- Widget config injected into the generated HTML ----
+WIDGET_SCRIPT_URL=https://djwdzs5n3r4m2.cloudfront.net/0.4/index.js
+API_BASE_URL_PROD=https://dialogue-foundry-backend-v2-test.onrender.com
+API_BASE_URL_TEST=https://dialogue-foundry-backend-smokebox-swjv.onrender.com/api
+
+# ---- Local Python crawler (runs on this machine) ----
+# Absolute path to the web-crawler checkout. Used both for the shallow demo-prep
+# scrape (scrape_page.py) and the full background crawl (orchestrator.py).
+CRAWLER_DIR=/Users/Peyton/Projects/web-crawler
+# Python interpreter to use (point at the crawler's venv for installed deps)
+CRAWLER_PYTHON=python3
+# Crawl depth for production vs test demos (background crawl only)
+CRAWLER_MAX_DEPTH_PROD=3
+CRAWLER_MAX_DEPTH_TEST=0
+# Max pages the shallow demo-prep scrape reads for content analysis
+SCRAPE_MAX_PAGES=5

--- a/apps/demo-setup/.eslintrc.cjs
+++ b/apps/demo-setup/.eslintrc.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: ['@dialogue-foundry/eslint-config'],
+  rules: {
+    'no-console': ['warn', { allow: ['warn', 'error', 'info'] }]
+  }
+}

--- a/apps/demo-setup/Dockerfile
+++ b/apps/demo-setup/Dockerfile
@@ -1,0 +1,25 @@
+# NOTE: This service spawns the local Python web-crawler as a subprocess.
+# If you run it in Docker, the crawler must be reachable from inside the
+# container (bind-mount CRAWLER_DIR and install its Python deps in the image,
+# or run the container with the crawler mounted). For the mac-mini, running
+# natively with pm2 (see ecosystem.config.cjs) is simpler.
+FROM node:24-slim AS build
+WORKDIR /repo
+
+# Copy workspace manifests for install caching
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
+COPY apps/demo-setup/package.json apps/demo-setup/
+COPY packages ./packages
+
+RUN corepack enable && pnpm install --filter @dialogue-foundry/demo-setup... --no-frozen-lockfile
+
+COPY apps/demo-setup ./apps/demo-setup
+RUN pnpm --filter @dialogue-foundry/demo-setup build
+
+FROM node:24-slim
+WORKDIR /repo
+COPY --from=build /repo ./
+ENV NODE_ENV=production
+WORKDIR /repo/apps/demo-setup
+EXPOSE 4000
+CMD ["node", "dist/index.js"]

--- a/apps/demo-setup/MACMINI_SETUP.md
+++ b/apps/demo-setup/MACMINI_SETUP.md
@@ -1,0 +1,113 @@
+# Mac-mini setup: demo-setup v2
+
+Instructions for a Claude Code (or other agent) session running **on the
+mac-mini** to pick up the `demo-setup` v2 pipeline and get it running. This
+replaces the old n8n "Demo Setup" workflow with `POST /demos`.
+
+This service depends on two repos, both need the feature branches below
+(merge to `main` first if the PRs have landed by the time you read this):
+
+- `dialogue-foundry` — branch `feat/demo-setup-pipeline` (PR [#75](https://github.com/Untap-AI/dialogue-foundry/pull/75))
+- `web-crawler` — branch `feat/demo-setup-scrape-endpoint` (PR [#14](https://github.com/Untap-AI/web-crawler/pull/14))
+
+## 1. Pull both repos
+
+```bash
+cd ~/Projects/dialogue-foundry && git fetch origin && git checkout main && git pull
+cd ~/Projects/web-crawler && git fetch origin && git checkout main && git pull
+```
+
+If the PRs haven't merged yet, check out the feature branches instead of `main`.
+
+## 2. web-crawler: Python env
+
+A venv already exists at `~/Projects/web-crawler/venv` on this machine for the
+existing deep-crawl workflow — reuse it (it already has crawl4ai + Playwright).
+If it's missing or you're on a fresh machine:
+
+```bash
+cd ~/Projects/web-crawler
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+playwright install chromium --with-deps
+```
+
+Sanity check the new shallow-scrape entrypoint runs standalone:
+
+```bash
+source venv/bin/activate
+python3 scrape_page.py https://example.com
+```
+
+Should print a single JSON line to stdout: `{"pages": [{"url": ..., "markdown": ...}], "homepageHtml": "..."}`.
+
+## 3. dialogue-foundry: build demo-setup
+
+```bash
+cd ~/Projects/dialogue-foundry
+pnpm install
+pnpm --filter @dialogue-foundry/demo-setup build
+```
+
+## 4. Configure `.env`
+
+```bash
+cd ~/Projects/dialogue-foundry/apps/demo-setup
+cp .env.example .env
+```
+
+Fill in (see `.env.example` for the full annotated list):
+
+| Var | Notes |
+|---|---|
+| `ANTHROPIC_API_KEY` | Claude key for this service's own analysis/brand-detection calls |
+| `CRAWLER_OPENAI_API_KEY` | **Different key/purpose** — the background deep crawl (`orchestrator.py`) still uses OpenAI internally. Don't conflate with `ANTHROPIC_API_KEY`. |
+| `SUPABASE_PROD_URL` / `SUPABASE_PROD_SERVICE_ROLE_KEY` | prod Supabase project |
+| `SUPABASE_TEST_URL` / `SUPABASE_TEST_SERVICE_ROLE_KEY` | test Supabase project |
+| `UPSTASH_VECTOR_REST_URL` / `UPSTASH_VECTOR_REST_TOKEN` | shared Upstash Vector index (namespace = `{companyId}-df`) |
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | S3 creds for the `demo.untap-ai.com` bucket |
+| `CRAWLER_DIR` | absolute path to the `web-crawler` checkout, e.g. `/Users/Peyton/Projects/web-crawler` |
+| `CRAWLER_PYTHON` | point at the venv's interpreter: `/Users/Peyton/Projects/web-crawler/venv/bin/python3` (not bare `python3`, so it picks up crawl4ai/Playwright) |
+| `DEMO_SETUP_API_KEYS` | comma-separated bearer tokens for `POST /demos`; leave empty only if this is on a locked-down private network |
+
+## 5. Start with pm2
+
+```bash
+cd ~/Projects/dialogue-foundry
+pm2 start apps/demo-setup/ecosystem.config.cjs
+pm2 save   # persist across reboots, assumes pm2 startup already configured on this machine
+```
+
+## 6. Verify
+
+```bash
+curl http://localhost:4000/health
+# {"status":"ok","timestamp":"..."}
+
+curl -X POST http://localhost:4000/demos \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <token from DEMO_SETUP_API_KEYS>' \
+  -d '{
+    "companyId": "test-co",
+    "companyName": "Test Co",
+    "companyWebsite": "https://example.com",
+    "companyEmail": "test@example.com"
+  }'
+# => {"demoUrl": "https://demo.untap-ai.com/test-co/"}
+```
+
+Then check:
+- The demo URL loads and looks reasonable (real logo/color/welcome message/suggestions, not fallback defaults).
+- `chat_configs` row written in the target Supabase project (`isProd: false` → test project).
+- `pm2 logs demo-setup` shows the background crawler subprocess started and (eventually) completed — this seeds the Upstash namespace for RAG answers.
+
+## Known limitations (carried over from PR #75)
+
+- SSRF guard (`lib/ssrf.ts`) validates the hostname once up front; a DNS-rebinding
+  attack between that check and the actual crawl4ai fetch isn't fully closed
+  (would require IP-pinning inside crawl4ai/Playwright). Acceptable residual risk
+  for now — the guard still blocks literal metadata/loopback/RFC1918 addresses.
+- Cold-start latency: each `POST /demos` spawns a fresh browser via `scrape_page.py`
+  (~seconds). If this becomes a bottleneck, the escape hatch is a warm long-running
+  local scrape service instead of a subprocess per request — not built yet.

--- a/apps/demo-setup/README.md
+++ b/apps/demo-setup/README.md
@@ -1,0 +1,79 @@
+# @dialogue-foundry/demo-setup
+
+Generates a custom Dialogue Foundry demo for a company from just its website.
+This is the code-based replacement for the old n8n "Demo Setup" sub-workflow.
+
+Given a company's name, website, and contact info it will:
+
+1. Validate the website against SSRF (reject private/loopback/reserved targets),
+   then scrape it with a **real browser** (crawl4ai, reusing the deep crawler's
+   anti-bot-tuned config) for page content + rendered homepage HTML
+2. Run **two Claude calls** (down from six LLM nodes in n8n):
+   - content analysis → business summary, contact phone, welcome message, 4 starter suggestions
+   - brand detection → logo, primary color, font family (only for values not supplied)
+3. Run a quality gate that repairs/falls back on any empty or malformed field
+   before anything is published
+4. Assemble the widget system prompt deterministically in code (no LLM)
+5. Upsert the `companies` and `chat_configs` rows in Supabase
+6. Build the primary + secondary widget pages (escaping the inlined JSON against
+   script-injection from untrusted scraped content) and upload them to the demo S3 bucket
+7. Kick off the local Python web-crawler in the background to seed the company's
+   Upstash Vector namespace (replaces the old per-company Render cron job)
+
+Pinecone and Tavily have both been removed. Scraping runs entirely through the
+local crawl4ai stack (no scraping vendor, no Node-side network fetches — closing
+the SSRF surface a naive `fetch()` would have). The crawler and backend both use
+Upstash Vector namespaces. The `chat_configs.pinecone_index_name` column is
+retained for backwards compatibility and holds the Upstash namespace
+(`{companyId}-df`).
+
+## API
+
+`POST /demos`
+
+```json
+{
+  "companyId": "acme-1234",
+  "companyName": "Acme Co",
+  "companyWebsite": "acme.com",
+  "companyEmail": "hello@acme.com",
+  "companyPhone": "555-123-4567",
+  "isProd": false,
+  "logoUrl": "",
+  "styles": { "primaryColor": "", "fontFamily": "" }
+}
+```
+
+Returns `201 { "demoUrl": "https://demo.untap-ai.com/acme-1234/" }`. The demo is
+live immediately; RAG answers become available once the background crawl
+finishes.
+
+`GET /health` → `{ "status": "ok" }`
+
+Set `DEMO_SETUP_API_KEYS` (comma-separated) to require a `Authorization: Bearer
+<key>` header on `POST /demos`. Leave unset on a private network.
+
+## Running on the mac-mini
+
+Because the service spawns local Python subprocesses (both the shallow
+demo-prep scrape and the background crawl), running it natively with pm2 is
+simplest:
+
+```bash
+cp apps/demo-setup/.env.example apps/demo-setup/.env   # fill in values
+pnpm --filter @dialogue-foundry/demo-setup build
+pm2 start apps/demo-setup/ecosystem.config.cjs
+```
+
+Point `CRAWLER_DIR` at your `web-crawler` checkout and `CRAWLER_PYTHON` at its
+virtualenv's Python so the crawler's dependencies are available.
+
+A `Dockerfile` is included as an alternative, but note the crawler must be
+reachable from inside the container (mount `CRAWLER_DIR` + install its Python
+deps) for the background crawl step to work.
+
+## Development
+
+```bash
+pnpm --filter @dialogue-foundry/demo-setup dev   # ts-node-dev, hot reload
+```

--- a/apps/demo-setup/ecosystem.config.cjs
+++ b/apps/demo-setup/ecosystem.config.cjs
@@ -1,0 +1,21 @@
+// pm2 config for running the demo-setup service natively on the mac-mini.
+// This is the recommended way to run it, since the service spawns the local
+// Python web-crawler as a subprocess.
+//
+//   pnpm --filter @dialogue-foundry/demo-setup build
+//   pm2 start apps/demo-setup/ecosystem.config.cjs
+module.exports = {
+  apps: [
+    {
+      name: 'demo-setup',
+      cwd: __dirname,
+      script: 'dist/index.js',
+      instances: 1,
+      autorestart: true,
+      max_memory_restart: '512M',
+      env: {
+        NODE_ENV: 'production'
+      }
+    }
+  ]
+}

--- a/apps/demo-setup/package.json
+++ b/apps/demo-setup/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@dialogue-foundry/demo-setup",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Generates a custom Dialogue Foundry demo for a company by scraping its website, building a tailored widget, and seeding the RAG namespace",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node-dev --respawn src/index.ts",
+    "lint": "eslint src --ext .ts",
+    "clean": "rm -rf dist && rm -rf node_modules"
+  },
+  "dependencies": {
+    "@ai-sdk/anthropic": "^2.0.0",
+    "@dialogue-foundry/tsconfig": "workspace:*",
+    "@supabase/supabase-js": "^2.49.1",
+    "ai": "^5.0.28",
+    "aws-sdk": "^2.1527.0",
+    "cheerio": "^1.0.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.7",
+    "express": "^4.21.2",
+    "zod": "^4.1.8"
+  },
+  "devDependencies": {
+    "@dialogue-foundry/eslint-config": "workspace:*",
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.17.24",
+    "eslint": "^8.57.1",
+    "ts-node": "^10.9.2",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/apps/demo-setup/src/config/env.ts
+++ b/apps/demo-setup/src/config/env.ts
@@ -1,0 +1,83 @@
+import dotenv from 'dotenv'
+
+dotenv.config()
+
+const required = (key: string): string => {
+  const value = process.env[key]
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${key}`)
+  }
+  return value
+}
+
+const optional = (key: string, fallback: string): string =>
+  process.env[key] || fallback
+
+export const env = {
+  port: parseInt(process.env.PORT || '4000', 10),
+  apiKeys: (process.env.DEMO_SETUP_API_KEYS || '')
+    .split(',')
+    .map(key => key.trim())
+    .filter(Boolean),
+
+  anthropicApiKey: () => required('ANTHROPIC_API_KEY'),
+  // Fast/cheap extraction model for content analysis + brand selection.
+  modelAnalysis: optional('MODEL_ANALYSIS', 'claude-haiku-4-5'),
+  // The generative copy step (welcome message + suggestions) can use a stronger
+  // model for a quality bump; defaults to the same cheap model.
+  modelBrand: optional('MODEL_BRAND', 'claude-haiku-4-5'),
+
+  // The background crawl (orchestrator.py) still uses OpenAI internally for
+  // content filtering/summarization — unrelated to this service's own Claude
+  // calls above.
+  crawlerOpenaiApiKey: () => required('CRAWLER_OPENAI_API_KEY'),
+
+  supabase: (isProd: boolean) =>
+    isProd
+      ? {
+          url: required('SUPABASE_PROD_URL'),
+          serviceKey: required('SUPABASE_PROD_SERVICE_ROLE_KEY')
+        }
+      : {
+          url: required('SUPABASE_TEST_URL'),
+          serviceKey: required('SUPABASE_TEST_SERVICE_ROLE_KEY')
+        },
+
+  upstash: () => ({
+    url: required('UPSTASH_VECTOR_REST_URL'),
+    token: required('UPSTASH_VECTOR_REST_TOKEN')
+  }),
+
+  aws: () => ({
+    accessKeyId: required('AWS_ACCESS_KEY_ID'),
+    secretAccessKey: required('AWS_SECRET_ACCESS_KEY'),
+    region: optional('AWS_REGION', 'us-east-1')
+  }),
+  demoBucket: optional('DEMO_S3_BUCKET', 'demo.untap-ai.com'),
+  demoBaseUrl: optional('DEMO_BASE_URL', 'https://demo.untap-ai.com'),
+
+  widgetScriptUrl: optional(
+    'WIDGET_SCRIPT_URL',
+    'https://djwdzs5n3r4m2.cloudfront.net/0.4/index.js'
+  ),
+  apiBaseUrl: (isProd: boolean) =>
+    isProd
+      ? optional(
+          'API_BASE_URL_PROD',
+          'https://dialogue-foundry-backend-v2-test.onrender.com'
+        )
+      : optional(
+          'API_BASE_URL_TEST',
+          'https://dialogue-foundry-backend-smokebox-swjv.onrender.com/api'
+        ),
+
+  crawlerDir: () => required('CRAWLER_DIR'),
+  crawlerPython: optional('CRAWLER_PYTHON', 'python3'),
+  crawlerMaxDepth: (isProd: boolean) =>
+    isProd
+      ? optional('CRAWLER_MAX_DEPTH_PROD', '3')
+      : optional('CRAWLER_MAX_DEPTH_TEST', '0'),
+
+  // Number of pages the demo-prep scrape reads for content analysis.
+  scrapeMaxPages: optional('SCRAPE_MAX_PAGES', '5')
+}

--- a/apps/demo-setup/src/index.ts
+++ b/apps/demo-setup/src/index.ts
@@ -1,0 +1,71 @@
+import { timingSafeEqual } from 'node:crypto'
+import express from 'express'
+import cors from 'cors'
+import { env } from './config/env'
+import { logger } from './lib/logger'
+import { demoInputSchema } from './types'
+import { runPipeline } from './pipeline/run-pipeline'
+import type {
+  NextFunction,
+  Request as ExpressRequest,
+  Response as ExpressResponse
+} from 'express'
+
+const app = express()
+app.use(cors())
+app.use(express.json({ limit: '2mb' }))
+
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok', timestamp: new Date().toISOString() })
+})
+
+/* Optional bearer-token auth. If DEMO_SETUP_API_KEYS is unset, auth is a no-op
+ * (fine for a locked-down mac-mini on a private network). */
+const timingSafeStringEqual = (a: string, b: string): boolean => {
+  const bufA = Buffer.from(a)
+  const bufB = Buffer.from(b)
+  // Compare against a fixed-length buffer first so differing lengths don't
+  // short-circuit before timingSafeEqual (which requires equal-length inputs).
+  if (bufA.length !== bufB.length) {
+    timingSafeEqual(bufA, bufA)
+    return false
+  }
+  return timingSafeEqual(bufA, bufB)
+}
+
+const requireApiKey = (
+  req: ExpressRequest,
+  res: ExpressResponse,
+  next: NextFunction
+) => {
+  if (env.apiKeys.length === 0) return next()
+  const token = req.headers.authorization?.replace(/^Bearer\s+/i, '')
+  if (token && env.apiKeys.some(key => timingSafeStringEqual(token, key))) {
+    return next()
+  }
+  return res.status(401).json({ error: 'Unauthorized' })
+}
+
+app.post('/demos', requireApiKey, async (req, res) => {
+  const parsed = demoInputSchema.safeParse(req.body)
+  if (!parsed.success) {
+    return res
+      .status(400)
+      .json({ error: 'Invalid input', issues: parsed.error.issues })
+  }
+
+  try {
+    const result = await runPipeline(parsed.data)
+    return res.status(201).json(result)
+  } catch (error) {
+    logger.error('Demo setup failed:', error)
+    return res.status(500).json({
+      error: 'Demo setup failed',
+      message: error instanceof Error ? error.message : String(error)
+    })
+  }
+})
+
+app.listen(env.port, () => {
+  logger.info(`demo-setup listening on port ${env.port}`)
+})

--- a/apps/demo-setup/src/integrations/crawler.ts
+++ b/apps/demo-setup/src/integrations/crawler.ts
@@ -1,0 +1,40 @@
+import { spawn } from 'node:child_process'
+import { env } from '../config/env'
+import { logger } from '../lib/logger'
+import type { PreparedInput } from '../types'
+
+/* Runs the local Python web-crawler (orchestrator.py) as a background
+ * subprocess. Replaces the old n8n step that provisioned a per-company Render
+ * cron job. The crawler crawls the site, chunks + summarizes content, and
+ * upserts it into the company's Upstash namespace.
+ *
+ * Fire-and-forget: we don't await the crawl (it can take minutes). Progress and
+ * failures are logged; the demo itself is already live before this runs. */
+export const startCrawl = (input: PreparedInput): void => {
+  const upstash = env.upstash()
+
+  const child = spawn(env.crawlerPython, ['orchestrator.py'], {
+    cwd: env.crawlerDir(),
+    env: {
+      ...process.env,
+      START_URLS: input.companyWebsite,
+      MAX_DEPTH: env.crawlerMaxDepth(input.isProd),
+      UPSTASH_VECTOR_REST_URL: upstash.url,
+      UPSTASH_VECTOR_REST_TOKEN: upstash.token,
+      UPSTASH_NAMESPACE: input.namespace,
+      OPENAI_API_KEY: env.crawlerOpenaiApiKey()
+    }
+  })
+
+  const tag = `[crawler ${input.companyId}]`
+  child.stdout.on('data', data => logger.info(tag, data.toString().trim()))
+  child.stderr.on('data', data => logger.warn(tag, data.toString().trim()))
+  child.on('error', error => logger.error(`${tag} failed to start:`, error))
+  child.on('close', code =>
+    code === 0
+      ? logger.info(`${tag} completed`)
+      : logger.error(`${tag} exited with code ${code}`)
+  )
+
+  logger.info(`${tag} started for ${input.companyWebsite}`)
+}

--- a/apps/demo-setup/src/integrations/s3.ts
+++ b/apps/demo-setup/src/integrations/s3.ts
@@ -1,0 +1,39 @@
+import { S3 } from 'aws-sdk'
+import { env } from '../config/env'
+import { logger } from '../lib/logger'
+
+let client: S3 | undefined
+const s3 = (): S3 => {
+  if (!client) {
+    const { accessKeyId, secretAccessKey, region } = env.aws()
+    client = new S3({ accessKeyId, secretAccessKey, region })
+  }
+  return client
+}
+
+const putHtml = (key: string, body: string): Promise<unknown> =>
+  s3()
+    .putObject({
+      Bucket: env.demoBucket,
+      Key: key,
+      Body: body,
+      ContentType: 'text/html'
+    })
+    .promise()
+
+/* Uploads the primary and secondary demo pages to the demo bucket at
+ * {companyId}/index.html and {companyId}/secondary/index.html. Returns the
+ * public demo URL. */
+export const uploadDemo = async (
+  companyId: string,
+  html: { primary: string; secondary: string }
+): Promise<string> => {
+  await Promise.all([
+    putHtml(`${companyId}/index.html`, html.primary),
+    putHtml(`${companyId}/secondary/index.html`, html.secondary)
+  ])
+
+  const demoUrl = `${env.demoBaseUrl}/${companyId}/`
+  logger.info(`Uploaded demo to ${demoUrl}`)
+  return demoUrl
+}

--- a/apps/demo-setup/src/integrations/scraper.ts
+++ b/apps/demo-setup/src/integrations/scraper.ts
@@ -1,0 +1,48 @@
+import { spawn } from 'node:child_process'
+import { env } from '../config/env'
+import { logger } from '../lib/logger'
+
+export type ScrapedPage = { url: string; markdown: string }
+export type ScrapeResult = { pages: ScrapedPage[]; homepageHtml: string }
+
+/* Runs the local crawl4ai scrape entrypoint (web-crawler/scrape_page.py) as a
+ * subprocess and returns its JSON payload. This replaces the old Tavily crawl +
+ * naive Node fetch() with the same real-browser stack the deep crawler uses, so
+ * JS-heavy and anti-bot sites render correctly — and no scraping network calls
+ * originate from the Node process (removing the SSRF surface). */
+export const scrapeForDemo = (website: string): Promise<ScrapeResult> =>
+  new Promise((resolve, reject) => {
+    const child = spawn(env.crawlerPython, ['scrape_page.py', website], {
+      cwd: env.crawlerDir(),
+      env: {
+        ...process.env,
+        SCRAPE_MAX_PAGES: env.scrapeMaxPages
+      }
+    })
+
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', data => (stdout += data.toString()))
+    child.stderr.on('data', data => {
+      stderr += data.toString()
+      logger.info('[scrape]', data.toString().trim())
+    })
+
+    child.on('error', reject)
+    child.on('close', code => {
+      if (code !== 0) {
+        return reject(
+          new Error(`scrape_page.py exited with code ${code}: ${stderr.trim()}`)
+        )
+      }
+      try {
+        const parsed = JSON.parse(stdout) as ScrapeResult
+        if (!parsed.pages?.length) {
+          return reject(new Error('Scraper returned no pages'))
+        }
+        resolve(parsed)
+      } catch (error) {
+        reject(new Error(`Failed to parse scraper output: ${error}`))
+      }
+    })
+  })

--- a/apps/demo-setup/src/integrations/supabase.ts
+++ b/apps/demo-setup/src/integrations/supabase.ts
@@ -1,0 +1,44 @@
+import { createClient } from '@supabase/supabase-js'
+import { env } from '../config/env'
+import { logger } from '../lib/logger'
+import type { PreparedInput } from '../types'
+
+const clientFor = (isProd: boolean) => {
+  const { url, serviceKey } = env.supabase(isProd)
+  return createClient(url, serviceKey, {
+    auth: { autoRefreshToken: false, persistSession: false }
+  })
+}
+
+/* Upserts the company row and its chat config. Idempotent so re-running the
+ * pipeline for the same company updates rather than errors. The chat_configs
+ * column is still named pinecone_index_name for backwards compatibility; the
+ * backend reads it as the Upstash namespace. */
+export const persistCompanyConfig = async (
+  input: PreparedInput,
+  systemPrompt: string
+): Promise<void> => {
+  const supabase = clientFor(input.isProd)
+
+  const { error: companyError } = await supabase
+    .from('companies')
+    .upsert({ id: input.companyId, name: input.companyName })
+  if (companyError) {
+    throw new Error(`Failed to upsert company: ${companyError.message}`)
+  }
+
+  const { error: configError } = await supabase.from('chat_configs').upsert(
+    {
+      company_id: input.companyId,
+      system_prompt: systemPrompt,
+      pinecone_index_name: input.namespace,
+      support_email: input.companyEmail
+    },
+    { onConflict: 'company_id' }
+  )
+  if (configError) {
+    throw new Error(`Failed to upsert chat config: ${configError.message}`)
+  }
+
+  logger.info(`Persisted company + chat config for ${input.companyId}`)
+}

--- a/apps/demo-setup/src/lib/logger.ts
+++ b/apps/demo-setup/src/lib/logger.ts
@@ -1,0 +1,13 @@
+/* Minimal structured logger. Prefixes every line with an ISO timestamp so pm2
+ * and Docker logs are greppable. */
+const line = (level: string, args: unknown[]) => [
+  `[${new Date().toISOString()}]`,
+  `[${level}]`,
+  ...args
+]
+
+export const logger = {
+  info: (...args: unknown[]) => console.info(...line('info', args)),
+  warn: (...args: unknown[]) => console.warn(...line('warn', args)),
+  error: (...args: unknown[]) => console.error(...line('error', args))
+}

--- a/apps/demo-setup/src/lib/ssrf.ts
+++ b/apps/demo-setup/src/lib/ssrf.ts
@@ -1,0 +1,95 @@
+import dns from 'node:dns/promises'
+import net from 'node:net'
+
+/* SSRF guard for the caller-supplied company website. The service resolves and
+ * scrapes whatever URL is submitted, so we must reject anything pointing at
+ * internal infrastructure (cloud metadata endpoints, loopback, private LANs)
+ * before any request is made.
+ *
+ * Known limitation: this validates the hostname once, up front; the actual
+ * fetch happens later in a separate crawl4ai/Playwright subprocess that
+ * re-resolves the hostname itself. A DNS host that resolves to a public IP
+ * here and rebinds to a private one by the time the browser connects would
+ * slip through (TOCTOU). Closing that fully means pinning the resolved IP
+ * through to the browser layer, which isn't practical with crawl4ai today.
+ * Accepted as a residual risk for now — this guard still blocks the common
+ * cases (literal metadata/loopback/RFC1918 addresses and hostnames that
+ * resolve to them at request time). */
+
+export class SsrfError extends Error {}
+
+const isPrivateIPv4 = (ip: string): boolean => {
+  const [a, b] = ip.split('.').map(Number)
+  if (a === 10) return true // 10.0.0.0/8
+  if (a === 127) return true // loopback
+  if (a === 0) return true // 0.0.0.0/8
+  if (a === 169 && b === 254) return true // link-local (incl. 169.254.169.254)
+  if (a === 172 && b >= 16 && b <= 31) return true // 172.16.0.0/12
+  if (a === 192 && b === 168) return true // 192.168.0.0/16
+  if (a === 100 && b >= 64 && b <= 127) return true // CGNAT 100.64.0.0/10
+  if (a >= 224) return true // multicast + reserved
+  return false
+}
+
+const isPrivateIPv6 = (ip: string): boolean => {
+  const lower = ip.toLowerCase()
+  if (lower === '::1' || lower === '::') return true // loopback / unspecified
+  if (lower.startsWith('fe80')) return true // link-local
+  if (lower.startsWith('fc') || lower.startsWith('fd')) return true // unique local
+  // IPv4-mapped (::ffff:a.b.c.d) — validate the embedded v4 address.
+  const mapped = lower.match(/::ffff:(\d+\.\d+\.\d+\.\d+)$/)
+  if (mapped) return isPrivateIPv4(mapped[1])
+  return false
+}
+
+const isPrivateAddress = (ip: string): boolean =>
+  net.isIPv4(ip) ? isPrivateIPv4(ip) : isPrivateIPv6(ip)
+
+/* Validates a URL for outbound fetching: must be http(s), must have a hostname,
+ * and every resolved address must be public. Returns the normalized href.
+ * Throws SsrfError on any violation. */
+export const assertSafeUrl = async (rawUrl: string): Promise<string> => {
+  let url: URL
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    throw new SsrfError(`Invalid URL: ${rawUrl}`)
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new SsrfError(`Unsupported protocol: ${url.protocol}`)
+  }
+
+  const host = url.hostname
+  if (!host) throw new SsrfError('URL has no hostname')
+
+  // A literal IP in the URL — check it directly.
+  if (net.isIP(host)) {
+    if (isPrivateAddress(host)) {
+      throw new SsrfError(`Refusing to fetch private address: ${host}`)
+    }
+    return url.href
+  }
+
+  // Resolve the hostname and reject if any address is private/reserved.
+  let addresses: { address: string }[]
+  try {
+    addresses = await dns.lookup(host, { all: true })
+  } catch {
+    throw new SsrfError(`Could not resolve host: ${host}`)
+  }
+
+  if (addresses.length === 0) {
+    throw new SsrfError(`Host did not resolve: ${host}`)
+  }
+
+  for (const { address } of addresses) {
+    if (isPrivateAddress(address)) {
+      throw new SsrfError(
+        `Host ${host} resolves to a private address (${address})`
+      )
+    }
+  }
+
+  return url.href
+}

--- a/apps/demo-setup/src/pipeline/analyze-content.ts
+++ b/apps/demo-setup/src/pipeline/analyze-content.ts
@@ -1,0 +1,80 @@
+import { anthropic } from '@ai-sdk/anthropic'
+import { generateObject, jsonSchema } from 'ai'
+import { env } from '../config/env'
+import type { ContentAnalysis } from '../types'
+
+/* JSON schema (rather than a zod schema) to stay decoupled from the workspace's
+ * mixed zod v3/v4 versions, which otherwise conflict with the AI SDK types. */
+const analysisSchema = jsonSchema<ContentAnalysis>({
+  type: 'object',
+  additionalProperties: false,
+  required: [
+    'businessName',
+    'summary',
+    'whatTheyOffer',
+    'whoItsFor',
+    'contactPhone',
+    'welcomeMessage',
+    'suggestions'
+  ],
+  properties: {
+    businessName: {
+      type: 'string',
+      description: 'The exact business name as it appears on the website'
+    },
+    summary: {
+      type: 'string',
+      description: 'A concise summary of what the business is and does'
+    },
+    whatTheyOffer: {
+      type: 'string',
+      description: 'The core products or services the business offers'
+    },
+    whoItsFor: {
+      type: 'string',
+      description: 'The target audience or ideal customer'
+    },
+    contactPhone: {
+      type: 'string',
+      description:
+        'The primary contact phone number, or empty string if none found'
+    },
+    welcomeMessage: {
+      type: 'string',
+      description:
+        'A warm, energetic, second-person greeting for a website chat widget. Mention the company name once. Max 60 words. Use \\n for line breaks.'
+    },
+    suggestions: {
+      type: 'array',
+      minItems: 4,
+      maxItems: 4,
+      description:
+        'Four full questions a customer would typically ask, each max 10 words',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['prompt'],
+        properties: { prompt: { type: 'string' } }
+      }
+    }
+  }
+})
+
+/* Single LLM call that replaces the old "Format Data for System Prompt" and
+ * "Formats scraped data" nodes. Extracts the business facts used to build the
+ * system prompt plus the widget welcome message and starter suggestions. */
+export const analyzeContent = async (
+  pages: string[]
+): Promise<ContentAnalysis> => {
+  const content = pages.slice(0, 5).join('\n\n---\n\n')
+
+  const { object } = await generateObject({
+    model: anthropic(env.modelAnalysis),
+    schema: analysisSchema,
+    system:
+      'You extract business details from website content for a customer-facing chat widget. Use only information present in the content, and use the business name exactly as it appears on the site.',
+    prompt: `Website content:\n\n${content}`
+  })
+
+  return object
+}

--- a/apps/demo-setup/src/pipeline/build-html.ts
+++ b/apps/demo-setup/src/pipeline/build-html.ts
@@ -1,0 +1,98 @@
+import { env } from '../config/env'
+import type { BrandResult, ContentAnalysis, PreparedInput } from '../types'
+
+type WidgetConfig = Record<string, unknown>
+
+const buildStyles = (input: PreparedInput, brand: BrandResult) => {
+  const styles: Record<string, string> = {
+    primaryColor: input.styles?.primaryColor || brand.brandColor,
+    fontFamily: input.styles?.fontFamily || brand.fontFamily
+  }
+  if (input.styles?.secondaryColor)
+    styles.secondaryColor = input.styles.secondaryColor
+  if (input.styles?.backgroundColor)
+    styles.backgroundColor = input.styles.backgroundColor
+  return styles
+}
+
+const buildConfig = (
+  input: PreparedInput,
+  analysis: ContentAnalysis,
+  brand: BrandResult,
+  theme?: 'secondary'
+): WidgetConfig => {
+  const logoUrl = input.logoUrl || brand.logoUrl
+  const config: WidgetConfig = {
+    chatConfig: {
+      apiBaseUrl: env.apiBaseUrl(input.isProd),
+      companyId: input.companyId
+    },
+    popupMessage: input.popupMessage || 'Have questions? Click here for help!',
+    openOnLoad: 'desktop-only',
+    poweredBy: { show: false },
+    welcomeMessage: analysis.welcomeMessage,
+    suggestions: analysis.suggestions,
+    styles: buildStyles(input, brand)
+  }
+
+  // A logo takes precedence; otherwise fall back to a text title.
+  if (logoUrl && logoUrl.trim()) {
+    config.logoUrl = logoUrl
+  } else {
+    config.title = input.title || input.companyName
+    config.logoUrl = ''
+  }
+
+  if (theme) config.theme = theme
+  return config
+}
+
+const LINE_SEPARATOR = String.fromCharCode(0x2028)
+const PARAGRAPH_SEPARATOR = String.fromCharCode(0x2029)
+
+/* Config values (welcomeMessage, suggestions, company name) come from an LLM
+ * reading untrusted scraped web content, so a page could contain a sequence
+ * that breaks out of the inline <script> block. Escape script-terminating
+ * sequences after serializing so the JSON payload can never close the tag or
+ * be misparsed as HTML (U+2028/2029 are valid in JSON but invalid in JS).
+ * Uses split/join instead of regex so the unicode separators don't have to
+ * appear as literal characters in source. */
+const escapeForInlineScript = (json: string): string =>
+  json
+    .split('<')
+    .join('\\u003c')
+    .split('-->')
+    .join('--\\u003e')
+    .split(LINE_SEPARATOR)
+    .join('\\u2028')
+    .split(PARAGRAPH_SEPARATOR)
+    .join('\\u2029')
+
+const renderHtml = (config: WidgetConfig): string =>
+  `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dialogue Foundry Chat Playground</title>
+  <script id="dialogue-foundry-config" type="application/json">
+${escapeForInlineScript(JSON.stringify(config, undefined, 2))}
+  </script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="${env.widgetScriptUrl}"></script>
+</body>
+</html>`
+
+/* Builds the primary and secondary widget landing pages. Unlike the n8n "Build
+ * HTML" node (which string-templated raw JSON and was fragile), this builds a
+ * real config object and serializes it, so escaping is always correct. */
+export const buildHtml = (
+  input: PreparedInput,
+  analysis: ContentAnalysis,
+  brand: BrandResult
+): { primary: string; secondary: string } => ({
+  primary: renderHtml(buildConfig(input, analysis, brand)),
+  secondary: renderHtml(buildConfig(input, analysis, brand, 'secondary'))
+})

--- a/apps/demo-setup/src/pipeline/detect-brand.ts
+++ b/apps/demo-setup/src/pipeline/detect-brand.ts
@@ -1,0 +1,71 @@
+import { anthropic } from '@ai-sdk/anthropic'
+import { generateObject, jsonSchema } from 'ai'
+import { env } from '../config/env'
+import type { BrandCandidates } from './extract-brand-candidates'
+import type { BrandResult, PreparedInput } from '../types'
+
+/* JSON schema (not zod) to stay decoupled from the workspace's mixed zod
+ * versions, which conflict with the AI SDK types. */
+const brandSchema = jsonSchema<BrandResult>({
+  type: 'object',
+  additionalProperties: false,
+  required: ['logoUrl', 'brandColor', 'fontFamily'],
+  properties: {
+    logoUrl: {
+      type: 'string',
+      description:
+        "The URL most likely to be the site's official brand logo (prefer SVG/PNG/JPG named logo/brand over favicons). Empty string if none suitable."
+    },
+    brandColor: {
+      type: 'string',
+      description:
+        'The primary brand color (bold, saturated, used for buttons/links/accents), not white/black/neutral backgrounds. Empty string if none found.'
+    },
+    fontFamily: {
+      type: 'string',
+      description:
+        "The website's primary body font family (or full font stack). Empty string if none found."
+    }
+  }
+})
+
+/* Single LLM call that replaces the old three "Determination" nodes (logo,
+ * color, font). Only invoked for signals the caller did not already supply.
+ * Returns the caller-supplied values verbatim for any field already set. */
+export const detectBrand = async (
+  input: PreparedInput,
+  candidates: BrandCandidates
+): Promise<BrandResult> => {
+  const supplied = {
+    logoUrl: input.logoUrl,
+    brandColor: input.styles?.primaryColor,
+    fontFamily: input.styles?.fontFamily
+  }
+
+  // Nothing to infer — skip the LLM entirely.
+  if (supplied.logoUrl && supplied.brandColor && supplied.fontFamily) {
+    return {
+      logoUrl: supplied.logoUrl,
+      brandColor: supplied.brandColor,
+      fontFamily: supplied.fontFamily
+    }
+  }
+
+  const { object } = await generateObject({
+    model: anthropic(env.modelBrand),
+    schema: brandSchema,
+    system:
+      'You are a web branding analyst. Given candidate logo URLs, colors, and font families extracted from a website, select the single best value for each, following the field descriptions.',
+    prompt: [
+      `Logo candidates:\n${candidates.logoCandidates.join('\n') || '(none)'}`,
+      `Color candidates:\n${candidates.colorCandidates.join('\n') || '(none)'}`,
+      `Font candidates:\n${candidates.fontCandidates.join('\n') || '(none)'}`
+    ].join('\n\n')
+  })
+
+  return {
+    logoUrl: supplied.logoUrl ?? object.logoUrl,
+    brandColor: supplied.brandColor ?? object.brandColor,
+    fontFamily: supplied.fontFamily ?? object.fontFamily
+  }
+}

--- a/apps/demo-setup/src/pipeline/extract-brand-candidates.ts
+++ b/apps/demo-setup/src/pipeline/extract-brand-candidates.ts
@@ -1,0 +1,98 @@
+import * as cheerio from 'cheerio'
+
+export type BrandCandidates = {
+  logoCandidates: string[]
+  colorCandidates: string[]
+  fontCandidates: string[]
+}
+
+const resolveUrl = (url: string, base: string): string => {
+  try {
+    return new URL(url, base).href
+  } catch {
+    return url
+  }
+}
+
+const scoreLogo = (url: string): number => {
+  const lower = url.toLowerCase()
+  let score = 0
+  if (lower.includes('logo')) score += 50
+  if (lower.includes('brand')) score += 25
+  if (lower.includes('icon')) score += 10
+  return score
+}
+
+const extractFontFamilies = (css: string): string[] => {
+  const fonts: string[] = []
+  const regex = /font-family\s*:\s*([^;{}]+)/gi
+  let match: RegExpExecArray | null
+  while ((match = regex.exec(css))) {
+    const font = match[1].trim().replace(/['"]/g, '')
+    if (font && !/inherit|initial|var\(/i.test(font)) fonts.push(font)
+  }
+  return fonts
+}
+
+const extractBackgroundColors = (css: string): string[] => {
+  const colors: string[] = []
+  const regex = /background(?:-color)?\s*:\s*([^;{}]+)/gi
+  let match: RegExpExecArray | null
+  while ((match = regex.exec(css))) {
+    const value = match[1].trim()
+    const color = value.match(/#[0-9a-fA-F]{3,8}|rgba?\([^)]+\)/)
+    if (color && !/gradient|url\(/i.test(value)) colors.push(color[0])
+  }
+  return colors
+}
+
+const dedupe = (items: string[], limit: number): string[] =>
+  Array.from(new Set(items)).slice(0, limit)
+
+/* Extracts raw brand-signal candidates (logo image URLs, background colors,
+ * font families) from the homepage HTML that crawl4ai already rendered. This is
+ * a pure function — it performs no network requests (the old version fetched the
+ * homepage and its stylesheets, which was the SSRF surface). External stylesheet
+ * contents aren't available here; we rely on the rendered inline styles and
+ * <style> blocks, which usually carry the brand color/font. The detect-brand LLM
+ * picks the best candidate; anything unfound falls back deterministically. */
+export const extractBrandCandidates = (
+  homepageHtml: string,
+  website: string
+): BrandCandidates => {
+  const $ = cheerio.load(homepageHtml)
+
+  const attrs = (selector: string, attr: string): string[] =>
+    $(selector)
+      .map((_, el) => $(el).attr(attr))
+      .get()
+      .filter((value): value is string => Boolean(value))
+
+  const logoCandidates = dedupe(
+    [
+      ...attrs(
+        'header img, img.logo, img[alt*="logo"], img[src*="logo"], [id*="logo"] img, [class*="logo"] img',
+        'src'
+      ),
+      ...attrs(
+        'meta[property="og:image"], meta[name="twitter:image"]',
+        'content'
+      ),
+      ...attrs('link[rel*="icon"]', 'href')
+    ].map(url => resolveUrl(url, website)),
+    8
+  ).sort((a, b) => scoreLogo(b) - scoreLogo(a))
+
+  const inlineStyles = attrs('[style]', 'style').join('\n')
+  const styleBlocks = $('style')
+    .map((_, el) => $(el).html() || '')
+    .get()
+    .join('\n')
+  const allCss = [inlineStyles, styleBlocks].join('\n')
+
+  return {
+    logoCandidates,
+    colorCandidates: dedupe(extractBackgroundColors(allCss), 12),
+    fontCandidates: dedupe(extractFontFamilies(allCss), 8)
+  }
+}

--- a/apps/demo-setup/src/pipeline/prepare-input.ts
+++ b/apps/demo-setup/src/pipeline/prepare-input.ts
@@ -1,0 +1,28 @@
+import { assertSafeUrl } from '../lib/ssrf'
+import type { DemoInput, PreparedInput } from '../types'
+
+const coerceBool = (value: boolean | string): boolean =>
+  typeof value === 'string' ? value.toLowerCase() === 'true' : value
+
+/* Normalizes the raw request into the shape the rest of the pipeline uses:
+ * ensures the website has a protocol, validates it against SSRF (the service
+ * scrapes whatever URL is submitted), and derives the RAG namespace. */
+export const prepareInput = async (
+  input: DemoInput
+): Promise<PreparedInput> => {
+  const rawWebsite = /^https?:\/\//i.test(input.companyWebsite)
+    ? input.companyWebsite
+    : `https://${input.companyWebsite}`
+
+  // Throws SsrfError for private/loopback/reserved targets or bad protocols.
+  const website = await assertSafeUrl(rawWebsite)
+
+  return {
+    ...input,
+    companyWebsite: website,
+    isProd: coerceBool(input.isProd),
+    // Legacy naming: the backend reads chat_configs.pinecone_index_name and
+    // uses it as the Upstash namespace. Keep the "-df" suffix for continuity.
+    namespace: `${input.companyId}-df`
+  }
+}

--- a/apps/demo-setup/src/pipeline/quality.ts
+++ b/apps/demo-setup/src/pipeline/quality.ts
@@ -1,0 +1,66 @@
+import { logger } from '../lib/logger'
+import type { BrandResult, ContentAnalysis } from '../types'
+
+const isValidHttpUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value)
+    return url.protocol === 'http:' || url.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+const isValidCssColor = (value: string): boolean =>
+  /^#[0-9a-fA-F]{3,8}$/.test(value) || /^rgba?\([^)]+\)$/i.test(value)
+
+const DEFAULT_BRAND_COLOR = '#1d4ed8'
+const DEFAULT_FONT_FAMILY = 'system-ui, sans-serif'
+
+/* Validates the generated analysis + brand fields before publish, and repairs
+ * anything that fails so a bad LLM output never ships a broken widget (empty
+ * welcome message, malformed color, garbage logo URL). Logs every repair so
+ * regressions are visible without failing the whole request. */
+export const enforceQuality = (
+  companyId: string,
+  analysis: ContentAnalysis,
+  brand: BrandResult
+): { analysis: ContentAnalysis; brand: BrandResult } => {
+  const safeAnalysis = { ...analysis }
+  const safeBrand = { ...brand }
+
+  if (!safeAnalysis.welcomeMessage?.trim()) {
+    logger.warn(`[quality ${companyId}] empty welcomeMessage, using fallback`)
+    safeAnalysis.welcomeMessage = `Welcome! Have a question? Just type it here and I'll help out.`
+  }
+
+  if (safeAnalysis.suggestions?.length !== 4) {
+    logger.warn(
+      `[quality ${companyId}] expected 4 suggestions, got ${safeAnalysis.suggestions?.length ?? 0}`
+    )
+    const prompts = safeAnalysis.suggestions?.map(s => s.prompt) ?? []
+    while (prompts.length < 4) prompts.push('What do you offer?')
+    safeAnalysis.suggestions = prompts.slice(0, 4).map(p => ({ prompt: p }))
+  }
+
+  if (safeBrand.brandColor && !isValidCssColor(safeBrand.brandColor)) {
+    logger.warn(
+      `[quality ${companyId}] invalid brandColor "${safeBrand.brandColor}", using default`
+    )
+    safeBrand.brandColor = DEFAULT_BRAND_COLOR
+  } else if (!safeBrand.brandColor) {
+    safeBrand.brandColor = DEFAULT_BRAND_COLOR
+  }
+
+  if (!safeBrand.fontFamily) {
+    safeBrand.fontFamily = DEFAULT_FONT_FAMILY
+  }
+
+  if (safeBrand.logoUrl && !isValidHttpUrl(safeBrand.logoUrl)) {
+    logger.warn(
+      `[quality ${companyId}] invalid logoUrl "${safeBrand.logoUrl}", dropping`
+    )
+    safeBrand.logoUrl = ''
+  }
+
+  return { analysis: safeAnalysis, brand: safeBrand }
+}

--- a/apps/demo-setup/src/pipeline/run-pipeline.ts
+++ b/apps/demo-setup/src/pipeline/run-pipeline.ts
@@ -1,0 +1,62 @@
+import { logger } from '../lib/logger'
+import { persistCompanyConfig } from '../integrations/supabase'
+import { uploadDemo } from '../integrations/s3'
+import { startCrawl } from '../integrations/crawler'
+import { scrapeForDemo } from '../integrations/scraper'
+import { prepareInput } from './prepare-input'
+import { extractBrandCandidates } from './extract-brand-candidates'
+import { analyzeContent } from './analyze-content'
+import { detectBrand } from './detect-brand'
+import { enforceQuality } from './quality'
+import { buildSystemPrompt } from './system-prompt'
+import { buildHtml } from './build-html'
+import type { DemoInput } from '../types'
+
+/* Orchestrates the full demo-setup flow. Everything up to and including the S3
+ * upload runs inline so the caller gets a working demo URL back. The full deep
+ * crawl (which seeds the RAG namespace) is kicked off last as a background job,
+ * since the demo is usable (minus RAG answers) before it finishes. */
+export const runPipeline = async (
+  rawInput: DemoInput
+): Promise<{ demoUrl: string }> => {
+  const input = await prepareInput(rawInput)
+  logger.info(
+    `Starting demo setup for ${input.companyId} (${input.companyWebsite})`
+  )
+
+  // Single real-browser scrape (crawl4ai) provides both the page content for
+  // analysis and the rendered homepage HTML for brand-candidate extraction.
+  const scraped = await scrapeForDemo(input.companyWebsite)
+  const pages = scraped.pages.map(page => page.markdown)
+  const candidates = extractBrandCandidates(
+    scraped.homepageHtml,
+    input.companyWebsite
+  )
+
+  // The two consolidated LLM calls, run in parallel.
+  const [rawAnalysis, rawBrand] = await Promise.all([
+    analyzeContent(pages),
+    detectBrand(input, candidates)
+  ])
+
+  const { analysis, brand } = enforceQuality(
+    input.companyId,
+    rawAnalysis,
+    rawBrand
+  )
+
+  const systemPrompt = buildSystemPrompt(input, analysis)
+
+  // Persist config and upload the demo pages in parallel.
+  const html = buildHtml(input, analysis, brand)
+  const [, demoUrl] = await Promise.all([
+    persistCompanyConfig(input, systemPrompt),
+    uploadDemo(input.companyId, html)
+  ])
+
+  // Fire-and-forget: seed the RAG namespace in the background.
+  startCrawl(input)
+
+  logger.info(`Demo setup complete for ${input.companyId}: ${demoUrl}`)
+  return { demoUrl }
+}

--- a/apps/demo-setup/src/pipeline/system-prompt.ts
+++ b/apps/demo-setup/src/pipeline/system-prompt.ts
@@ -1,0 +1,62 @@
+import type { ContentAnalysis, PreparedInput } from '../types'
+
+/* Static guidance appended to every generated system prompt. Ported from the
+ * n8n flow but rewritten for current models (gpt-5.x, Claude 4.x, etc.), which
+ * follow instructions literally — the old ALL-CAPS "NEVER / MUST / KEEP TO 100
+ * TOKENS" scaffolding was written to overcome older models' reluctance and now
+ * over-triggers. This is plain declarative guidance. Assembled deterministically
+ * in code (no LLM) so it's a pure function of the inputs. */
+const buildGuidelines = (email: string, phone: string) => `
+---
+
+## Asking for email vs. offering contact info
+
+On each message, decide whether to ask for the user's email, offer contact info, or neither.
+
+Do neither when it's the first message, when you asked for their email in your last message, or when you already shared contact info for the same topic.
+
+For broad or FAQ-style questions ("What do you offer?", "Where are you located?"), just answer.
+
+For follow-ups that show real intent:
+- If they're weighing options, asking about timelines or availability, or want personalized help, invite them to share their email so the team can follow up. Example: "I'd be happy to help further — could you share your email so the team can follow up directly?"
+- If they're describing a problem or need direct help, share the contact info instead: Email: **${email}**, Phone: **${phone}**.
+
+Don't repeat an email request or contact info unless the user raises a new topic. The only reason to collect an email is so the team can follow up.
+
+---
+
+## Links
+- Add a relevant link when one exists, using natural anchor text like "Learn more here".
+- Use links exactly as they appear in the provided context — never invent or edit a URL.
+- Render links as Markdown ([text](url)), not bare URLs. One per response is usually enough.
+
+## Style
+- Ground answers in the provided company details and retrieved context; if something isn't covered, suggest contacting the team.
+- Keep responses concise and easy to scan: short paragraphs, **bold** for key points, bullet or numbered lists where they help, and '##'/'###' headings only when a response spans multiple topics (never open with a heading).
+- Don't reveal internal operations. If asked something off-topic, steer back to the company and its offerings.
+`
+
+/* Builds the full system prompt from the analysis and input. Replaces the n8n
+ * "Creates system prompt" (LLM) + "Combine Prompt" (code) nodes — this used to
+ * be an LLM call doing pure string interpolation. */
+export const buildSystemPrompt = (
+  input: PreparedInput,
+  analysis: ContentAnalysis
+): string => {
+  const { companyName, companyEmail } = input
+  const phone = analysis.contactPhone || input.companyPhone || ''
+
+  const intro = `You are the website chat assistant for **${companyName}**.
+Help visitors with accurate, helpful information about **${analysis.whatTheyOffer}** and keep them engaged. When someone shows interest, encourage them to share their email so the **${companyName}** team can follow up.
+
+## Contact
+Email: **${companyEmail}**
+Phone: **${phone}**
+
+## Guidelines
+- Be friendly, warm, and enthusiastic about ${companyName}.
+- Use the company details provided; don't infer or paraphrase unstated facts. If unsure, suggest contacting the team.
+- Be concise while fully answering the question.`
+
+  return `${intro}\n${buildGuidelines(companyEmail, phone)}`
+}

--- a/apps/demo-setup/src/types.ts
+++ b/apps/demo-setup/src/types.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod'
+
+/* Styles the caller can pre-supply. Anything omitted is inferred from the
+ * scraped site during brand detection. */
+export const stylesSchema = z
+  .object({
+    primaryColor: z.string().optional(),
+    secondaryColor: z.string().optional(),
+    backgroundColor: z.string().optional(),
+    fontFamily: z.string().optional()
+  })
+  .optional()
+
+/* Request body for POST /demos. Mirrors the inputs the old n8n "Start" trigger
+ * accepted, minus the fields it only passed through untouched. */
+export const demoInputSchema = z.object({
+  // Used as an S3 key path segment (see integrations/s3.ts) — restrict to a
+  // safe slug so it can't traverse into another tenant's prefix.
+  companyId: z
+    .string()
+    .min(1)
+    .regex(/^[a-zA-Z0-9_-]+$/, 'companyId must be alphanumeric, - or _ only'),
+  companyName: z.string().min(1),
+  companyWebsite: z.string().min(1),
+  companyEmail: z.string().email(),
+  companyPhone: z.string().optional(),
+  isProd: z.union([z.boolean(), z.string()]).default(false),
+  // Optional overrides — when provided we skip inferring them from the site.
+  logoUrl: z.string().optional(),
+  title: z.string().optional(),
+  popupMessage: z.string().optional(),
+  styles: stylesSchema
+})
+
+export type DemoInput = z.infer<typeof demoInputSchema>
+
+/* Normalized input produced by prepare-input. */
+export type PreparedInput = Omit<DemoInput, 'isProd'> & {
+  isProd: boolean
+  companyWebsite: string
+  namespace: string
+}
+
+export type Suggestion = { prompt: string }
+
+/* Output of the single content-analysis LLM call. */
+export type ContentAnalysis = {
+  businessName: string
+  summary: string
+  whatTheyOffer: string
+  whoItsFor: string
+  contactPhone: string
+  welcomeMessage: string
+  suggestions: Suggestion[]
+}
+
+/* Output of the single brand-detection LLM call. */
+export type BrandResult = {
+  logoUrl: string
+  brandColor: string
+  fontFamily: string
+}

--- a/apps/demo-setup/tsconfig.json
+++ b/apps/demo-setup/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@dialogue-foundry/tsconfig/node.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "noEmit": false
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,64 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(@types/node@20.17.30)(typescript@5.8.3)
 
+  apps/demo-setup:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^2.0.0
+        version: 2.0.85(zod@4.4.3)
+      '@dialogue-foundry/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
+      '@supabase/supabase-js':
+        specifier: ^2.49.1
+        version: 2.49.4
+      ai:
+        specifier: ^5.0.28
+        version: 5.0.28(zod@4.4.3)
+      aws-sdk:
+        specifier: ^2.1527.0
+        version: 2.1692.0
+      cheerio:
+        specifier: ^1.0.0
+        version: 1.2.0
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.5
+      dotenv:
+        specifier: ^16.4.7
+        version: 16.4.7
+      express:
+        specifier: ^4.21.2
+        version: 4.21.2
+      zod:
+        specifier: ^4.1.8
+        version: 4.4.3
+    devDependencies:
+      '@dialogue-foundry/eslint-config':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config
+      '@types/cors':
+        specifier: ^2.8.17
+        version: 2.8.17
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.21
+      '@types/node':
+        specifier: ^20.17.24
+        version: 20.17.30
+      eslint:
+        specifier: ^8.57.1
+        version: 8.57.1
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@20.17.30)(typescript@5.8.3)
+      ts-node-dev:
+        specifier: ^2.0.0
+        version: 2.0.0(@types/node@20.17.30)(typescript@5.8.3)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.8.3
+
   apps/frontend:
     dependencies:
       '@ai-sdk/react':
@@ -366,6 +424,12 @@ importers:
 
 packages:
 
+  '@ai-sdk/anthropic@2.0.85':
+    resolution: {integrity: sha512-ozfPUXb5cnXyFWXyY0hRFi8fudgNDr+FAuP2J1HTRhPjkTHTSFLbPSVRXEXCVoJhfl1IboF+xNDZs35nOHDU7w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/gateway@1.0.15':
     resolution: {integrity: sha512-xySXoQ29+KbGuGfmDnABx+O6vc7Gj7qugmj1kGpn0rW0rQNn6UKUuvscKMzWyv1Uv05GyC1vqHq8ZhEOLfXscQ==}
     engines: {node: '>=18'}
@@ -384,6 +448,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@3.0.28':
+    resolution: {integrity: sha512-bXlX1WX7E50a2N+AJW+1a/x63m52aPhm+6xYe5THxWrx9vW9NR7E2Ay+1G1ndlCdMdYKo2Fnsd7kBhuyQPaphw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@3.0.7':
     resolution: {integrity: sha512-o3BS5/t8KnBL3ubP8k3w77AByOypLm+pkIL/DCw0qKkhDbvhCy+L3hRTGPikpdb8WHcylAeKsjgwOxhj4cqTUA==}
     engines: {node: '>=18'}
@@ -392,6 +462,10 @@ packages:
 
   '@ai-sdk/provider@2.0.0':
     resolution: {integrity: sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@2.0.3':
+    resolution: {integrity: sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==}
     engines: {node: '>=18'}
 
   '@ai-sdk/react@2.0.28':
@@ -2075,6 +2149,9 @@ packages:
     resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
     engines: {node: '>=18'}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
 
@@ -2154,6 +2231,13 @@ packages:
 
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+
+  cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+
+  cheerio@1.2.0:
+    resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
+    engines: {node: '>=20.18.1'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -2290,6 +2374,13 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
+
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
@@ -2423,6 +2514,19 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
   dotenv@16.4.7:
     resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
     engines: {node: '>=12'}
@@ -2484,6 +2588,9 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  encoding-sniffer@0.2.1:
+    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
   enhanced-resolve@5.18.3:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
     engines: {node: '>=10.13.0'}
@@ -2494,6 +2601,14 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   env-paths@2.2.1:
@@ -3082,6 +3197,9 @@ packages:
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
@@ -3859,6 +3977,9 @@ packages:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
 
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -4006,6 +4127,15 @@ packages:
   parse-passwd@1.0.0:
     resolution: {integrity: sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==}
     engines: {node: '>=0.10.0'}
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5-parser-stream@7.1.2:
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -4802,6 +4932,10 @@ packages:
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
+
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
@@ -4942,6 +5076,15 @@ packages:
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -5092,10 +5235,19 @@ packages:
   zod@4.1.5:
     resolution: {integrity: sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@ai-sdk/anthropic@2.0.85(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.28(zod@4.4.3)
+      zod: 4.4.3
 
   '@ai-sdk/gateway@1.0.15(zod@3.24.2)':
     dependencies:
@@ -5109,6 +5261,12 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.7(zod@4.1.5)
       zod: 4.1.5
 
+  '@ai-sdk/gateway@1.0.15(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.7(zod@4.4.3)
+      zod: 4.4.3
+
   '@ai-sdk/openai@2.0.67(zod@4.1.5)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
@@ -5121,6 +5279,13 @@ snapshots:
       '@standard-schema/spec': 1.0.0
       eventsource-parser: 3.0.6
       zod: 4.1.5
+
+  '@ai-sdk/provider-utils@3.0.28(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@standard-schema/spec': 1.0.0
+      eventsource-parser: 3.0.6
+      zod: 4.4.3
 
   '@ai-sdk/provider-utils@3.0.7(zod@3.24.2)':
     dependencies:
@@ -5136,7 +5301,18 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 4.1.5
 
+  '@ai-sdk/provider-utils@3.0.7(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@standard-schema/spec': 1.0.0
+      eventsource-parser: 3.0.6
+      zod: 4.4.3
+
   '@ai-sdk/provider@2.0.0':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@2.0.3':
     dependencies:
       json-schema: 0.4.0
 
@@ -6814,6 +6990,14 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 4.1.5
 
+  ai@5.0.28(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 1.0.15(zod@4.4.3)
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.7(zod@4.4.3)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.4.3
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -7019,6 +7203,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  boolbase@1.0.0: {}
+
   brace-expansion@1.1.11:
     dependencies:
       balanced-match: 1.0.2
@@ -7094,6 +7280,29 @@ snapshots:
   character-reference-invalid@2.0.1: {}
 
   chardet@0.7.0: {}
+
+  cheerio-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.2.2
+      css-what: 6.2.2
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+
+  cheerio@1.2.0:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      encoding-sniffer: 0.2.1
+      htmlparser2: 10.1.0
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 7.28.0
+      whatwg-mimetype: 4.0.0
 
   chokidar@3.6.0:
     dependencies:
@@ -7214,6 +7423,16 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-what@6.2.2: {}
 
   csstype@3.1.3: {}
 
@@ -7337,6 +7556,24 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
   dotenv@16.4.7: {}
 
   dotenv@17.2.1: {}
@@ -7390,6 +7627,11 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
+  encoding-sniffer@0.2.1:
+    dependencies:
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
+
   enhanced-resolve@5.18.3:
     dependencies:
       graceful-fs: 4.2.11
@@ -7401,6 +7643,10 @@ snapshots:
       strip-ansi: 6.0.1
 
   entities@4.5.0: {}
+
+  entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   env-paths@2.2.1: {}
 
@@ -8247,6 +8493,13 @@ snapshots:
 
   html-url-attributes@3.0.1: {}
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   http-errors@2.0.0:
     dependencies:
       depd: 2.0.0
@@ -9074,6 +9327,10 @@ snapshots:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
 
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -9239,6 +9496,19 @@ snapshots:
   parse-ms@4.0.0: {}
 
   parse-passwd@1.0.0: {}
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.3.0
+
+  parse5-parser-stream@7.1.2:
+    dependencies:
+      parse5: 7.3.0
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   parseurl@1.3.3: {}
 
@@ -10177,6 +10447,8 @@ snapshots:
 
   undici-types@6.19.8: {}
 
+  undici@7.28.0: {}
+
   unicorn-magic@0.3.0: {}
 
   unified@11.0.5:
@@ -10307,6 +10579,12 @@ snapshots:
   web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@3.0.1: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
 
   whatwg-url@5.0.0:
     dependencies:
@@ -10457,5 +10735,7 @@ snapshots:
   zod@3.24.2: {}
 
   zod@4.1.5: {}
+
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary
- Replaces Tavily + naive `fetch()` scraping with the existing crawl4ai/Playwright stack, spawned via a new subprocess entrypoint in `web-crawler` ([Untap-AI/web-crawler#feat/demo-setup-scrape-endpoint](https://github.com/Untap-AI/web-crawler/pull/new/feat/demo-setup-scrape-endpoint)) — this PR depends on that one being merged for the service to actually run end-to-end.
- Switches the service's own generative LLM steps (content analysis, brand detection) from OpenAI to Claude (`@ai-sdk/anthropic`, `claude-haiku-4-5`); the background deep crawl still uses OpenAI internally (separate `CRAWLER_OPENAI_API_KEY`) and is unaffected.
- Re-architects the pipeline: pure-Node brand-candidate extraction (no more Node-side network fetches), a quality gate that repairs bad/empty LLM output before publish, and a softened system-prompt template (dropped 2020-era ALL-CAPS/token-limit scaffolding that current models follow too literally).
- Folds in two security fixes: an SSRF guard (`lib/ssrf.ts`) on the caller-supplied company URL, and XSS-safe escaping of the JSON payload inlined into the generated widget HTML (`build-html.ts`).
- Also fixes two issues a background review caught on this commit: a path-traversal risk where `companyId` was used unvalidated as an S3 key segment (now restricted to `[a-zA-Z0-9_-]+`), and a non-constant-time comparison on the bearer-token auth check (now `crypto.timingSafeEqual`). A third finding (DNS-rebinding TOCTOU between the SSRF check and the actual scrape) is documented as an accepted residual risk in `lib/ssrf.ts` — fully closing it would require pinning resolved IPs through the Playwright layer, which isn't practical with crawl4ai today.

## Test plan
- [x] `pnpm --filter @dialogue-foundry/demo-setup build` and `pnpm exec eslint src --ext .ts` clean
- [x] Manual SSRF test: `POST /demos` with `companyWebsite: http://169.254.169.254/` and `http://localhost` rejected before any scrape
- [x] Manual XSS test: payload containing `</script><script>alert(2)</script>-->` confirmed escaped in generated HTML
- [ ] End-to-end `POST /demos` against a real site on the mac-mini once both PRs are merged and the crawler subprocess is wired up

🤖 Generated with [Claude Code](https://claude.com/claude-code)