### PR TITLE
feat(demo-setup): build demos from a Supabase queue and email the link

### DIFF
--- a/apps/backend/supabase/migrations/20260708000000_add_demo_requests_table.sql
+++ b/apps/backend/supabase/migrations/20260708000000_add_demo_requests_table.sql
@@ -1,0 +1,224 @@
+-- Demo Requests Queue
+--
+-- The public marketing site (Untap-website) inserts a row here when a prospect
+-- submits the demo form. The demo-setup service on the mac-mini polls this
+-- table, claims rows, builds the demo, and emails the link. Using a table as
+-- the queue keeps the mac-mini off the public internet and makes the row a
+-- durable job record that survives pm2 restarts and reboots.
+--
+-- Additive only: this creates one new table, its indexes, and three new
+-- functions. It does not touch companies, chat_configs, chats, messages,
+-- analytics_events, or dashboard_users.
+
+-- Prerequisites, both created by 20240601000000_chat_configs_table.sql. Assert
+-- rather than CREATE OR REPLACE them: update_updated_at_column() is shared by
+-- every other table's trigger, and silently redefining it here would be exactly
+-- the kind of cross-table change this migration promises not to make.
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_proc
+        WHERE proname = 'update_updated_at_column'
+          AND pronamespace = 'public'::regnamespace
+    ) THEN
+        RAISE EXCEPTION 'public.update_updated_at_column() is missing; apply 20240601000000_chat_configs_table.sql first';
+    END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS demo_requests (
+    -- ID
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+
+    -- FORM PAYLOAD
+    website_url TEXT NOT NULL CHECK (char_length(website_url) <= 2048),
+    company_name TEXT NOT NULL CHECK (char_length(company_name) <= 200),
+    contact_email TEXT NOT NULL CHECK (char_length(contact_email) <= 255),
+    delivery_email TEXT NOT NULL CHECK (char_length(delivery_email) <= 255),
+
+    -- CONTEXT DATA
+    source_path TEXT,
+    user_agent TEXT,
+
+    -- DERIVED (set on first claim, reused on retry)
+    -- Deliberately NOT a FK to companies(id): the worker persists this before
+    -- the pipeline creates the companies row, so a FK would reject the update.
+    company_id TEXT CHECK (char_length(company_id) <= 100),
+    demo_url TEXT,
+    is_prod BOOLEAN NOT NULL DEFAULT TRUE,
+
+    -- QUEUE STATE
+    status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'processing', 'complete', 'failed')),
+    attempts INT NOT NULL DEFAULT 0,
+    max_attempts INT NOT NULL DEFAULT 3,
+    last_error TEXT,
+    claimed_at TIMESTAMPTZ,
+    claimed_by TEXT,
+    completed_at TIMESTAMPTZ,
+
+    -- METADATA
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ,
+
+    -- CONSTRAINTS
+    CONSTRAINT demo_requests_contact_email_format_check CHECK (
+        contact_email ~* '^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$'
+    ),
+    CONSTRAINT demo_requests_delivery_email_format_check CHECK (
+        delivery_email ~* '^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$'
+    )
+);
+
+-- Partial index matching the claim query's WHERE + ORDER BY exactly.
+CREATE INDEX IF NOT EXISTS idx_demo_requests_claimable
+    ON demo_requests (created_at)
+    WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS idx_demo_requests_status ON demo_requests (status);
+CREATE INDEX IF NOT EXISTS idx_demo_requests_delivery_email ON demo_requests (delivery_email);
+CREATE INDEX IF NOT EXISTS idx_demo_requests_company_id ON demo_requests (company_id);
+
+-- Dedupe and throttle in one, with no extra infrastructure: a second request
+-- for a site that is already queued or building raises 23505, which the API
+-- route turns into a 409. Completed/failed rows are excluded so a site can be
+-- re-demoed later.
+CREATE UNIQUE INDEX IF NOT EXISTS demo_requests_one_active_per_site
+    ON demo_requests (lower(website_url))
+    WHERE status IN ('pending', 'processing');
+
+-- Keep updated_at current (function defined in 20240601000000_chat_configs_table.sql).
+-- CREATE TRIGGER has no IF NOT EXISTS in PG15, so guard it to stay re-runnable.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_trigger
+        WHERE tgname = 'update_demo_requests_updated_at'
+          AND tgrelid = 'public.demo_requests'::regclass
+    ) THEN
+        CREATE TRIGGER update_demo_requests_updated_at
+        BEFORE UPDATE ON demo_requests
+        FOR EACH ROW
+        EXECUTE PROCEDURE update_updated_at_column();
+    END IF;
+END $$;
+
+-- Service-role access only. No policies are defined on purpose: the earlier
+-- remote_schema dump blanket-grants DML on public tables to `anon`, so RLS is
+-- the only thing standing between the public anon key and this table.
+ALTER TABLE demo_requests ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE demo_requests IS 'Queue of demo build requests submitted from the marketing site. Polled and claimed by the demo-setup worker on the mac-mini.';
+COMMENT ON COLUMN demo_requests.contact_email IS 'The prospect''s business contact address. Becomes chat_configs.support_email for the generated demo.';
+COMMENT ON COLUMN demo_requests.delivery_email IS 'Where the "your demo is ready" email is sent. Defaults to contact_email when the form leaves it blank.';
+COMMENT ON COLUMN demo_requests.company_id IS 'Generated slug (demo-<name>-<rand>). Set on first claim and reused across retries so a retry does not orphan the previous attempt''s S3 objects and Upstash namespace.';
+COMMENT ON COLUMN demo_requests.claimed_by IS 'Worker id holding this row. Used by reap_stale_demo_requests to recover rows whose worker died.';
+COMMENT ON COLUMN demo_requests.attempts IS 'Incremented on every claim, including reclaims after a stale-claim reap. Once it reaches max_attempts the row is no longer claimable.';
+
+-- Atomically claim up to p_batch pending rows.
+--
+-- This exists as a function purely because FOR UPDATE SKIP LOCKED cannot be
+-- expressed through PostgREST, and SKIP LOCKED is what guarantees two workers
+-- (or two concurrent slots in one worker) never grab the same row.
+--
+-- SECURITY INVOKER (the implicit default) is deliberate. The only caller holds
+-- the service_role key, which already bypasses RLS, so SECURITY DEFINER would
+-- buy nothing -- and would actively hurt: Postgres grants EXECUTE to PUBLIC by
+-- default and Supabase exposes every public-schema function as a PostgREST RPC
+-- endpoint, so a definer function here would let anyone holding the *public*
+-- anon key claim every row and starve the worker.
+CREATE OR REPLACE FUNCTION claim_demo_requests(p_worker TEXT, p_batch INT)
+RETURNS SETOF demo_requests
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY
+    UPDATE demo_requests d
+       SET status = 'processing',
+           claimed_at = NOW(),
+           claimed_by = p_worker,
+           attempts = d.attempts + 1
+     WHERE d.id IN (
+         SELECT id
+           FROM demo_requests
+          WHERE status = 'pending'
+            AND attempts < max_attempts
+          ORDER BY created_at
+          LIMIT p_batch
+          FOR UPDATE SKIP LOCKED
+     )
+    RETURNING d.*;
+END;
+$$;
+
+-- Recover rows whose worker died mid-job (pm2 restart, reboot, OOM kill).
+-- Rows with attempts left go back to 'pending'; exhausted ones go to 'failed'
+-- so the worker can alert on them.
+CREATE OR REPLACE FUNCTION reap_stale_demo_requests(p_stale_minutes INT)
+RETURNS SETOF demo_requests
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY
+    UPDATE demo_requests d
+       SET status = CASE WHEN d.attempts >= d.max_attempts THEN 'failed' ELSE 'pending' END,
+           last_error = concat_ws(' ', d.last_error, '[reaped: stale claim]'),
+           claimed_at = NULL,
+           claimed_by = NULL
+     WHERE d.status = 'processing'
+       AND d.claimed_at < NOW() - make_interval(mins => p_stale_minutes)
+    RETURNING d.*;
+END;
+$$;
+
+-- Hand rows back on graceful shutdown, refunding the attempt the claim consumed.
+--
+-- Deliberately asymmetric with reap_stale_demo_requests, which does NOT refund:
+-- a clean SIGTERM means the attempt never really happened, so charging for it
+-- would let three pm2 restarts permanently fail a healthy request. A hard death
+-- (crash, OOM, hang) does charge, so a URL that reliably kills the worker
+-- exhausts its retries instead of crash-looping forever.
+CREATE OR REPLACE FUNCTION release_demo_requests(p_ids UUID[])
+RETURNS SETOF demo_requests
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY
+    UPDATE demo_requests d
+       SET status = 'pending',
+           attempts = GREATEST(d.attempts - 1, 0),
+           claimed_at = NULL,
+           claimed_by = NULL
+     WHERE d.id = ANY(p_ids)
+       AND d.status = 'processing'
+    RETURNING d.*;
+END;
+$$;
+
+-- Defense in depth: strip the default PUBLIC execute grant so these are never
+-- reachable via PostgREST with the anon key, even if RLS is later misconfigured.
+--
+-- Order matters. Postgres grants EXECUTE on new functions to PUBLIC, and every
+-- role inherits from PUBLIC -- including service_role. So revoking PUBLIC also
+-- takes execute away from the worker unless service_role is granted explicitly
+-- afterwards. Grant it back below rather than relying on Supabase's default
+-- privileges, which are invisible here and easy to change out from under us.
+REVOKE EXECUTE ON FUNCTION claim_demo_requests(TEXT, INT) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION claim_demo_requests(TEXT, INT) FROM anon;
+REVOKE EXECUTE ON FUNCTION claim_demo_requests(TEXT, INT) FROM authenticated;
+REVOKE EXECUTE ON FUNCTION reap_stale_demo_requests(INT) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION reap_stale_demo_requests(INT) FROM anon;
+REVOKE EXECUTE ON FUNCTION reap_stale_demo_requests(INT) FROM authenticated;
+REVOKE EXECUTE ON FUNCTION release_demo_requests(UUID[]) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION release_demo_requests(UUID[]) FROM anon;
+REVOKE EXECUTE ON FUNCTION release_demo_requests(UUID[]) FROM authenticated;
+
+GRANT EXECUTE ON FUNCTION claim_demo_requests(TEXT, INT) TO service_role;
+GRANT EXECUTE ON FUNCTION reap_stale_demo_requests(INT) TO service_role;
+GRANT EXECUTE ON FUNCTION release_demo_requests(UUID[]) TO service_role;
+
+-- Same reasoning for the table itself.
+REVOKE ALL ON TABLE demo_requests FROM anon;
+REVOKE ALL ON TABLE demo_requests FROM authenticated;
+GRANT ALL ON TABLE demo_requests TO service_role;

--- a/apps/demo-setup/.env.example
+++ b/apps/demo-setup/.env.example
@@ -33,7 +33,7 @@ DEMO_BASE_URL=https://demo.untap-ai.com
 
 # ---- Widget config injected into the generated HTML ----
 WIDGET_SCRIPT_URL=https://djwdzs5n3r4m2.cloudfront.net/0.4/index.js
-API_BASE_URL_PROD=https://dialogue-foundry-backend-v2-test.onrender.com
+API_BASE_URL_PROD=https://dialogue-foundry-backend-v2-test.onrender.com/api
 API_BASE_URL_TEST=https://dialogue-foundry-backend-smokebox-swjv.onrender.com/api
 
 # ---- Local Python crawler (runs on this machine) ----
@@ -43,7 +43,31 @@ CRAWLER_DIR=/Users/Peyton/Projects/web-crawler
 # Python interpreter to use (point at the crawler's venv for installed deps)
 CRAWLER_PYTHON=python3
 # Crawl depth for production vs test demos (background crawl only)
-CRAWLER_MAX_DEPTH_PROD=3
+CRAWLER_MAX_DEPTH_PROD=0
 CRAWLER_MAX_DEPTH_TEST=0
 # Max pages the shallow demo-prep scrape reads for content analysis
 SCRAPE_MAX_PAGES=5
+# Run crawl4ai's Chrome headless (no visible browser windows during scrape/crawl)
+HEADLESS=true
+# Hard bounds on the two Python subprocesses. Both spawn Chrome; a hung browser
+# would otherwise pin a queue worker slot forever.
+SCRAPE_TIMEOUT_MS=300000
+CRAWL_TIMEOUT_MS=900000
+
+# ---- Demo request queue ----
+# The worker polls the demo_requests table (always in the PROD Supabase project)
+# for form submissions from the marketing site, builds each demo, and emails the
+# link. Set to false to run this service as a plain POST /demos API only.
+DEMO_QUEUE_ENABLED=true
+DEMO_POLL_INTERVAL_MS=10000
+# Demos built concurrently. Each spawns Chrome twice, so keep this small.
+DEMO_WORKER_CONCURRENCY=2
+# A row claimed longer than this is presumed dead and returned to the queue.
+# Must exceed SCRAPE_TIMEOUT_MS + CRAWL_TIMEOUT_MS or the worker refuses to boot.
+DEMO_STALE_MINUTES=30
+
+# ---- SendGrid (demo-ready notification) ----
+# Optional. Unset means the "your demo is ready" email is skipped with a warning.
+SENDGRID_API_KEY=
+# Where failure alerts go. Successes already CC the team via the SendGrid template.
+DEMO_ALERT_EMAIL=contact@untap-ai.com

--- a/apps/demo-setup/ecosystem.config.cjs
+++ b/apps/demo-setup/ecosystem.config.cjs
@@ -12,7 +12,13 @@ module.exports = {
       script: 'dist/index.js',
       instances: 1,
       autorestart: true,
-      max_memory_restart: '512M',
+      // The queue worker runs DEMO_WORKER_CONCURRENCY demos at once, each
+      // spawning Chrome twice (shallow scrape, then deep crawl). 512M tripped
+      // mid-crawl, and a restart kills in-flight browsers.
+      max_memory_restart: '2G',
+      // Give shutdown time to kill crawl subprocesses and hand queue rows back
+      // before pm2 escalates to SIGKILL.
+      kill_timeout: 10000,
       env: {
         NODE_ENV: 'production'
       }

--- a/apps/demo-setup/package.json
+++ b/apps/demo-setup/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@ai-sdk/anthropic": "^2.0.0",
     "@dialogue-foundry/tsconfig": "workspace:*",
+    "@sendgrid/mail": "^8.1.5",
     "@supabase/supabase-js": "^2.49.1",
     "ai": "^5.0.28",
     "aws-sdk": "^2.1527.0",

--- a/apps/demo-setup/src/config/env.ts
+++ b/apps/demo-setup/src/config/env.ts
@@ -13,6 +13,18 @@ const required = (key: string): string => {
 const optional = (key: string, fallback: string): string =>
   process.env[key] || fallback
 
+const optionalInt = (key: string, fallback: number): number => {
+  const raw = process.env[key]
+  if (!raw) return fallback
+  const parsed = parseInt(raw, 10)
+  if (Number.isNaN(parsed)) {
+    throw new Error(
+      `Environment variable ${key} must be an integer, got "${raw}"`
+    )
+  }
+  return parsed
+}
+
 export const env = {
   port: parseInt(process.env.PORT || '4000', 10),
   apiKeys: (process.env.DEMO_SETUP_API_KEYS || '')
@@ -64,7 +76,7 @@ export const env = {
     isProd
       ? optional(
           'API_BASE_URL_PROD',
-          'https://dialogue-foundry-backend-v2-test.onrender.com'
+          'https://dialogue-foundry-backend-v2-test.onrender.com/api'
         )
       : optional(
           'API_BASE_URL_TEST',
@@ -75,9 +87,35 @@ export const env = {
   crawlerPython: optional('CRAWLER_PYTHON', 'python3'),
   crawlerMaxDepth: (isProd: boolean) =>
     isProd
-      ? optional('CRAWLER_MAX_DEPTH_PROD', '3')
+      ? optional('CRAWLER_MAX_DEPTH_PROD', '0')
       : optional('CRAWLER_MAX_DEPTH_TEST', '0'),
 
   // Number of pages the demo-prep scrape reads for content analysis.
-  scrapeMaxPages: optional('SCRAPE_MAX_PAGES', '5')
+  scrapeMaxPages: optional('SCRAPE_MAX_PAGES', '5'),
+
+  // Hard bounds on the two Python subprocesses. Both spawn Chrome, and a hung
+  // browser would otherwise pin a queue worker slot forever.
+  scrapeTimeoutMs: optionalInt('SCRAPE_TIMEOUT_MS', 5 * 60 * 1000),
+  crawlTimeoutMs: optionalInt('CRAWL_TIMEOUT_MS', 15 * 60 * 1000),
+
+  /* ---- Demo request queue (Supabase table polled by the worker) ---- */
+  // The queue always lives in the prod project, independent of a row's is_prod
+  // (which only selects where that demo's company config gets written).
+  queueSupabase: () => ({
+    url: required('SUPABASE_PROD_URL'),
+    serviceKey: required('SUPABASE_PROD_SERVICE_ROLE_KEY')
+  }),
+  queueEnabled: optional('DEMO_QUEUE_ENABLED', 'true') !== 'false',
+  queuePollIntervalMs: optionalInt('DEMO_POLL_INTERVAL_MS', 10_000),
+  queueConcurrency: optionalInt('DEMO_WORKER_CONCURRENCY', 2),
+  // A row claimed longer than this is assumed dead (pm2 restart, reboot, OOM)
+  // and is returned to the queue. Must exceed scrape + crawl timeouts combined,
+  // or the reaper will steal rows out from under a healthy worker.
+  queueStaleMinutes: optionalInt('DEMO_STALE_MINUTES', 30),
+
+  /* ---- SendGrid (demo-ready notification) ---- */
+  // Optional: unset means email is skipped with a warning, so `POST /demos` and
+  // local runs work without it.
+  sendgridApiKey: (): string | undefined => process.env.SENDGRID_API_KEY,
+  demoAlertEmail: optional('DEMO_ALERT_EMAIL', 'contact@untap-ai.com')
 }

--- a/apps/demo-setup/src/index.ts
+++ b/apps/demo-setup/src/index.ts
@@ -5,6 +5,7 @@ import { env } from './config/env'
 import { logger } from './lib/logger'
 import { demoInputSchema } from './types'
 import { runPipeline } from './pipeline/run-pipeline'
+import { startWorker, stopWorker } from './queue/worker'
 import type {
   NextFunction,
   Request as ExpressRequest,
@@ -55,8 +56,23 @@ app.post('/demos', requireApiKey, async (req, res) => {
   }
 
   try {
-    const result = await runPipeline(parsed.data)
-    return res.status(201).json(result)
+    const { demoUrl, crawlDone } = await runPipeline(parsed.data)
+
+    // This route returns as soon as the demo is live, so nobody awaits the
+    // crawl. Swallow its rejection here or it becomes an unhandled rejection
+    // and takes the process down.
+    void (async () => {
+      try {
+        await crawlDone
+      } catch (error) {
+        logger.error(
+          `Background crawl failed for ${parsed.data.companyId}:`,
+          error
+        )
+      }
+    })()
+
+    return res.status(201).json({ demoUrl })
   } catch (error) {
     logger.error('Demo setup failed:', error)
     return res.status(500).json({
@@ -66,6 +82,25 @@ app.post('/demos', requireApiKey, async (req, res) => {
   }
 })
 
-app.listen(env.port, () => {
+const server = app.listen(env.port, () => {
   logger.info(`demo-setup listening on port ${env.port}`)
 })
+
+startWorker()
+
+/* pm2 sends SIGTERM on restart/stop. Without this, in-flight crawls become
+ * orphaned Chrome processes and their queue rows sit 'processing' until the
+ * reaper times them out. */
+let shuttingDown = false
+const shutdown = async (signal: string) => {
+  if (shuttingDown) return
+  shuttingDown = true
+  logger.info(`Received ${signal}, shutting down`)
+
+  server.close()
+  await stopWorker()
+  process.exit(0)
+}
+
+process.on('SIGTERM', () => void shutdown('SIGTERM'))
+process.on('SIGINT', () => void shutdown('SIGINT'))

--- a/apps/demo-setup/src/integrations/crawler.ts
+++ b/apps/demo-setup/src/integrations/crawler.ts
@@ -1,40 +1,82 @@
 import { spawn } from 'node:child_process'
 import { env } from '../config/env'
 import { logger } from '../lib/logger'
+import { killProcessTree } from '../lib/process-tree'
+import type { ChildProcess } from 'node:child_process'
 import type { PreparedInput } from '../types'
 
-/* Runs the local Python web-crawler (orchestrator.py) as a background
- * subprocess. Replaces the old n8n step that provisioned a per-company Render
- * cron job. The crawler crawls the site, chunks + summarizes content, and
- * upserts it into the company's Upstash namespace.
- *
- * Fire-and-forget: we don't await the crawl (it can take minutes). Progress and
- * failures are logged; the demo itself is already live before this runs. */
-export const startCrawl = (input: PreparedInput): void => {
-  const upstash = env.upstash()
+/* Every crawl currently running, so a SIGTERM can take their browsers down with
+ * it instead of orphaning them. */
+const activeCrawls = new Set<ChildProcess>()
 
-  const child = spawn(env.crawlerPython, ['orchestrator.py'], {
-    cwd: env.crawlerDir(),
-    env: {
-      ...process.env,
-      START_URLS: input.companyWebsite,
-      MAX_DEPTH: env.crawlerMaxDepth(input.isProd),
-      UPSTASH_VECTOR_REST_URL: upstash.url,
-      UPSTASH_VECTOR_REST_TOKEN: upstash.token,
-      UPSTASH_NAMESPACE: input.namespace,
-      OPENAI_API_KEY: env.crawlerOpenaiApiKey()
-    }
-  })
-
-  const tag = `[crawler ${input.companyId}]`
-  child.stdout.on('data', data => logger.info(tag, data.toString().trim()))
-  child.stderr.on('data', data => logger.warn(tag, data.toString().trim()))
-  child.on('error', error => logger.error(`${tag} failed to start:`, error))
-  child.on('close', code =>
-    code === 0
-      ? logger.info(`${tag} completed`)
-      : logger.error(`${tag} exited with code ${code}`)
-  )
-
-  logger.info(`${tag} started for ${input.companyWebsite}`)
+export const killActiveCrawls = (): void => {
+  for (const child of activeCrawls) killProcessTree(child)
+  activeCrawls.clear()
 }
+
+/* Runs the local Python web-crawler (orchestrator.py) as a subprocess. Replaces
+ * the old n8n step that provisioned a per-company Render cron job. The crawler
+ * crawls the site, chunks + summarizes content, and upserts it into the
+ * company's Upstash namespace.
+ *
+ * Resolves when the crawl succeeds, rejects on nonzero exit or timeout. The
+ * queue worker awaits this before emailing the demo link — the widget is live
+ * beforehand but its RAG namespace is empty, so an early email would send the
+ * prospect to a chatbot that knows nothing about them. */
+export const runCrawl = (input: PreparedInput): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const upstash = env.upstash()
+    const tag = `[crawler ${input.companyId}]`
+
+    const child = spawn(env.crawlerPython, ['orchestrator.py'], {
+      cwd: env.crawlerDir(),
+      // Lead a new process group so we can kill Chrome along with Python.
+      detached: true,
+      env: {
+        ...process.env,
+        START_URLS: input.companyWebsite,
+        MAX_DEPTH: env.crawlerMaxDepth(input.isProd),
+        UPSTASH_VECTOR_REST_URL: upstash.url,
+        UPSTASH_VECTOR_REST_TOKEN: upstash.token,
+        UPSTASH_NAMESPACE: input.namespace,
+        OPENAI_API_KEY: env.crawlerOpenaiApiKey(),
+        // web-crawler/.env may carry an EXPECTED_CHUNKS tuned for a different
+        // (large-site deep-crawl) workflow. Demo-setup crawls one company site
+        // per call with wildly varying size, so opt out of that threshold.
+        EXPECTED_CHUNKS: '0'
+      }
+    })
+
+    activeCrawls.add(child)
+
+    // `error` and `close` can both fire, and the timeout can race either. Settle
+    // exactly once so a late `close` can't resolve a promise we already rejected.
+    let settled = false
+    const settle = (error?: Error) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      activeCrawls.delete(child)
+      if (error) reject(error)
+      else resolve()
+    }
+
+    const timer = setTimeout(() => {
+      logger.error(`${tag} exceeded ${env.crawlTimeoutMs}ms; killing`)
+      killProcessTree(child)
+      settle(new Error(`Crawl timed out after ${env.crawlTimeoutMs}ms`))
+    }, env.crawlTimeoutMs)
+
+    child.stdout.on('data', data => logger.info(tag, data.toString().trim()))
+    child.stderr.on('data', data => logger.warn(tag, data.toString().trim()))
+    child.on('error', error => settle(error))
+    child.on('close', code => {
+      if (code === 0) {
+        logger.info(`${tag} completed`)
+        return settle()
+      }
+      settle(new Error(`orchestrator.py exited with code ${code}`))
+    })
+
+    logger.info(`${tag} started for ${input.companyWebsite}`)
+  })

--- a/apps/demo-setup/src/integrations/scraper.ts
+++ b/apps/demo-setup/src/integrations/scraper.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process'
 import { env } from '../config/env'
 import { logger } from '../lib/logger'
+import { killProcessTree } from '../lib/process-tree'
 
 export type ScrapedPage = { url: string; markdown: string }
 export type ScrapeResult = { pages: ScrapedPage[]; homepageHtml: string }
@@ -9,16 +10,36 @@ export type ScrapeResult = { pages: ScrapedPage[]; homepageHtml: string }
  * subprocess and returns its JSON payload. This replaces the old Tavily crawl +
  * naive Node fetch() with the same real-browser stack the deep crawler uses, so
  * JS-heavy and anti-bot sites render correctly — and no scraping network calls
- * originate from the Node process (removing the SSRF surface). */
+ * originate from the Node process (removing the SSRF surface).
+ *
+ * Awaited inline by the pipeline, so a hung Chrome here would pin a queue worker
+ * slot indefinitely. Bounded by SCRAPE_TIMEOUT_MS, and spawned detached so the
+ * timeout can kill the browser along with Python. */
 export const scrapeForDemo = (website: string): Promise<ScrapeResult> =>
   new Promise((resolve, reject) => {
     const child = spawn(env.crawlerPython, ['scrape_page.py', website], {
       cwd: env.crawlerDir(),
+      detached: true,
       env: {
         ...process.env,
         SCRAPE_MAX_PAGES: env.scrapeMaxPages
       }
     })
+
+    let settled = false
+    const settle = (error?: Error, value?: ScrapeResult) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      if (error) reject(error)
+      else resolve(value as ScrapeResult)
+    }
+
+    const timer = setTimeout(() => {
+      logger.error(`[scrape] exceeded ${env.scrapeTimeoutMs}ms; killing`)
+      killProcessTree(child)
+      settle(new Error(`Scrape timed out after ${env.scrapeTimeoutMs}ms`))
+    }, env.scrapeTimeoutMs)
 
     let stdout = ''
     let stderr = ''
@@ -28,21 +49,21 @@ export const scrapeForDemo = (website: string): Promise<ScrapeResult> =>
       logger.info('[scrape]', data.toString().trim())
     })
 
-    child.on('error', reject)
+    child.on('error', error => settle(error))
     child.on('close', code => {
       if (code !== 0) {
-        return reject(
+        return settle(
           new Error(`scrape_page.py exited with code ${code}: ${stderr.trim()}`)
         )
       }
       try {
         const parsed = JSON.parse(stdout) as ScrapeResult
         if (!parsed.pages?.length) {
-          return reject(new Error('Scraper returned no pages'))
+          return settle(new Error('Scraper returned no pages'))
         }
-        resolve(parsed)
+        settle(undefined, parsed)
       } catch (error) {
-        reject(new Error(`Failed to parse scraper output: ${error}`))
+        settle(new Error(`Failed to parse scraper output: ${error}`))
       }
     })
   })

--- a/apps/demo-setup/src/integrations/sendgrid.ts
+++ b/apps/demo-setup/src/integrations/sendgrid.ts
@@ -1,0 +1,101 @@
+import sgMail from '@sendgrid/mail'
+import { env } from '../config/env'
+import { logger } from '../lib/logger'
+
+/* Ported verbatim from the SendGrid node of the n8n workflow this service
+ * replaces. The template renders the demo link itself from company_id, so
+ * company_id is the only dynamic field it needs. */
+const DEMO_READY_TEMPLATE_ID = 'd-75e4a3c87e304f638c01730516bc9396'
+const FROM = { email: 'demo@untap-ai.com', name: 'Untap AI' } as const
+const INTERNAL_CC = [
+  { email: 'james@untap-ai.com' },
+  { email: 'peyton@untap-ai.com' }
+]
+
+/* Deliberately not the backend's sendgrid-service: that module throws at import
+ * when SENDGRID_API_KEY is unset and hardcodes a chat_configs lookup we don't
+ * want here. Configure lazily instead, so the service still boots (and
+ * `POST /demos` still works) without a mail key. */
+let configured = false
+const client = (): typeof sgMail | undefined => {
+  const apiKey = env.sendgridApiKey()
+  if (!apiKey) return undefined
+  if (!configured) {
+    sgMail.setApiKey(apiKey)
+    configured = true
+  }
+  return sgMail
+}
+
+/* Tells the prospect their demo is ready. Sent only after the crawl has seeded
+ * the RAG namespace — before that the widget is live but knows nothing.
+ *
+ * Never throws: a SendGrid outage must not fail a demo that was built fine. The
+ * caller records the boolean so a missed email is visible in the queue row. */
+export const sendDemoReadyEmail = async ({
+  to,
+  companyId
+}: {
+  to: string
+  companyId: string
+}): Promise<boolean> => {
+  const mail = client()
+  if (!mail) {
+    logger.warn(
+      `SENDGRID_API_KEY unset — skipping demo-ready email to ${to} for ${companyId}`
+    )
+    return false
+  }
+
+  try {
+    await mail.send({
+      personalizations: [
+        {
+          to: [{ email: to }],
+          cc: INTERNAL_CC,
+          dynamicTemplateData: { company_id: companyId }
+        }
+      ],
+      from: FROM,
+      templateId: DEMO_READY_TEMPLATE_ID
+    })
+    logger.info(`Demo-ready email sent to ${to} for ${companyId}`)
+    return true
+  } catch (error) {
+    logger.error(`Failed to send demo-ready email for ${companyId}:`, error)
+    // SendGrid puts the actionable detail (bad template id, unverified sender)
+    // in the response body, not the Error message.
+    const body = (error as { response?: { body?: unknown } }).response?.body
+    if (body) logger.error('SendGrid response body:', JSON.stringify(body))
+    return false
+  }
+}
+
+/* Fires when a request exhausts its retries. The success path already CCs the
+ * team via the template above, so this only covers failures. */
+export const sendInternalAlert = async ({
+  subject,
+  body
+}: {
+  subject: string
+  body: string
+}): Promise<boolean> => {
+  const mail = client()
+  if (!mail) {
+    logger.warn(`SENDGRID_API_KEY unset — skipping internal alert: ${subject}`)
+    return false
+  }
+
+  try {
+    await mail.send({
+      to: env.demoAlertEmail,
+      from: FROM,
+      subject,
+      text: body
+    })
+    return true
+  } catch (error) {
+    logger.error('Failed to send internal alert:', error)
+    return false
+  }
+}

--- a/apps/demo-setup/src/lib/process-tree.ts
+++ b/apps/demo-setup/src/lib/process-tree.ts
@@ -1,0 +1,32 @@
+import { logger } from './logger'
+import type { ChildProcess } from 'node:child_process'
+
+/* Kills a child and everything it spawned.
+ *
+ * The Python crawler launches Chrome via Playwright. Signalling only the Python
+ * PID leaves those browsers running — that's how orchestrator.py runs ended up
+ * lingering for hours holding CLOSE_WAIT sockets. Children spawned with
+ * `detached: true` lead their own process group, so a negative PID signals the
+ * whole group in one call. */
+export const killProcessTree = (
+  child: ChildProcess,
+  signal: NodeJS.Signals = 'SIGKILL'
+): void => {
+  // exitCode is a number once the child has exited, and null while it runs.
+  if (child.pid === undefined || typeof child.exitCode === 'number') return
+
+  try {
+    process.kill(-child.pid, signal)
+  } catch (error) {
+    // ESRCH: the group is already gone, which is the outcome we wanted. Anything
+    // else means we may have leaked a process, so fall back to the bare PID.
+    if ((error as NodeJS.ErrnoException).code !== 'ESRCH') {
+      logger.warn(`Failed to kill process group ${child.pid}:`, error)
+      try {
+        child.kill(signal)
+      } catch {
+        // The child exited between the two calls. Nothing left to kill.
+      }
+    }
+  }
+}

--- a/apps/demo-setup/src/lib/slug.ts
+++ b/apps/demo-setup/src/lib/slug.ts
@@ -1,0 +1,55 @@
+import { randomBytes } from 'node:crypto'
+
+// Leaves room for the "demo-" prefix and "-xxxxxxxx" suffix inside chat_configs'
+// and demo_requests' 100-char company_id limit.
+const MAX_SLUG_BODY = 40
+
+// Latin letters that NFKD leaves alone because they're distinct letters rather
+// than a base plus a combining mark. Without these, "Ø" becomes "-", not "o".
+const LATIN_FOLD: Record<string, string> = {
+  ø: 'o',
+  æ: 'ae',
+  œ: 'oe',
+  ð: 'd',
+  þ: 'th',
+  ł: 'l',
+  đ: 'd',
+  ß: 'ss'
+}
+
+/* Derives the company id for a demo request.
+ *
+ * Two things depend on the exact output: it is the S3 key prefix the demo is
+ * uploaded under, and it is the only variable the "demo ready" SendGrid template
+ * receives — the template builds demo.untap-ai.com/{{company_id}}/ from it. A
+ * change here is a change to the link the prospect clicks.
+ *
+ * The "demo-" prefix keeps generated demos in a namespace of their own. Without
+ * it a prospect named "Acme" would slug to `acme` and the pipeline's upsert into
+ * `companies` / `chat_configs` would silently overwrite a real customer's
+ * system prompt and vector namespace.
+ *
+ * The random suffix means two prospects with the same company name never collide
+ * (and no pre-flight SELECT is needed, so there's no check-then-insert race).
+ * It is 4 bytes rather than 2 because a collision is not a retry — the second
+ * demo would upsert over the first's chat_config and S3 objects, leaving the
+ * first prospect's link serving someone else's company. */
+export const deriveCompanyId = (companyName: string): string => {
+  const body = companyName
+    // Fold accents to ASCII first, so "Ünïcødé Çafé" slugs to "unicode-cafe"
+    // rather than "n-c-d-af". The result is the URL the prospect clicks.
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[øæœðþłđß]/g, char => LATIN_FOLD[char])
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, MAX_SLUG_BODY)
+    // Slicing mid-run can leave a trailing dash.
+    .replace(/-+$/, '')
+
+  const suffix = randomBytes(4).toString('hex')
+
+  // Names with nothing ASCII-alphanumeric in them (e.g. all-CJK) slug to empty.
+  return body ? `demo-${body}-${suffix}` : `demo-${suffix}`
+}

--- a/apps/demo-setup/src/pipeline/run-pipeline.ts
+++ b/apps/demo-setup/src/pipeline/run-pipeline.ts
@@ -1,7 +1,8 @@
 import { logger } from '../lib/logger'
+import { env } from '../config/env'
 import { persistCompanyConfig } from '../integrations/supabase'
 import { uploadDemo } from '../integrations/s3'
-import { startCrawl } from '../integrations/crawler'
+import { runCrawl } from '../integrations/crawler'
 import { scrapeForDemo } from '../integrations/scraper'
 import { prepareInput } from './prepare-input'
 import { extractBrandCandidates } from './extract-brand-candidates'
@@ -12,17 +13,32 @@ import { buildSystemPrompt } from './system-prompt'
 import { buildHtml } from './build-html'
 import type { DemoInput } from '../types'
 
+export type PipelineResult = {
+  demoUrl: string
+  /* Resolves when the RAG namespace is seeded. The demo URL is already live and
+   * correctly branded before this settles, but the widget can't answer anything
+   * company-specific until it does. `POST /demos` ignores it (logging failures);
+   * the queue worker awaits it before emailing the prospect. */
+  crawlDone: Promise<void>
+}
+
 /* Orchestrates the full demo-setup flow. Everything up to and including the S3
- * upload runs inline so the caller gets a working demo URL back. The full deep
- * crawl (which seeds the RAG namespace) is kicked off last as a background job,
- * since the demo is usable (minus RAG answers) before it finishes. */
+ * upload runs inline so the caller gets a working demo URL back. The deep crawl
+ * is started last and handed back as a promise, since the demo is usable (minus
+ * RAG answers) before it finishes. */
 export const runPipeline = async (
   rawInput: DemoInput
-): Promise<{ demoUrl: string }> => {
+): Promise<PipelineResult> => {
   const input = await prepareInput(rawInput)
   logger.info(
     `Starting demo setup for ${input.companyId} (${input.companyWebsite})`
   )
+
+  // Fail before we publish anything if the crawl couldn't run anyway. Resolving
+  // these lazily inside runCrawl meant a missing Upstash var surfaced as a 500
+  // only after S3 and Supabase had already been written.
+  env.upstash()
+  env.crawlerOpenaiApiKey()
 
   // Single real-browser scrape (crawl4ai) provides both the page content for
   // analysis and the rendered homepage HTML for brand-candidate extraction.
@@ -54,9 +70,9 @@ export const runPipeline = async (
     uploadDemo(input.companyId, html)
   ])
 
-  // Fire-and-forget: seed the RAG namespace in the background.
-  startCrawl(input)
+  // Seed the RAG namespace. Started here, awaited (or not) by the caller.
+  const crawlDone = runCrawl(input)
 
   logger.info(`Demo setup complete for ${input.companyId}: ${demoUrl}`)
-  return { demoUrl }
+  return { demoUrl, crawlDone }
 }

--- a/apps/demo-setup/src/queue/repo.ts
+++ b/apps/demo-setup/src/queue/repo.ts
@@ -1,0 +1,92 @@
+import { createClient } from '@supabase/supabase-js'
+import { env } from '../config/env'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { DemoRequestRow } from '../types'
+
+let cached: SupabaseClient | undefined
+
+/* The queue always lives in the prod project, regardless of a row's is_prod —
+ * that flag only selects where the generated company config is written. */
+const client = (): SupabaseClient => {
+  if (!cached) {
+    const { url, serviceKey } = env.queueSupabase()
+    cached = createClient(url, serviceKey, {
+      auth: { autoRefreshToken: false, persistSession: false }
+    })
+  }
+  return cached
+}
+
+/* Atomically takes up to `batch` pending rows. Two workers (or two slots in one
+ * worker) can call this concurrently without ever claiming the same row — see
+ * the FOR UPDATE SKIP LOCKED in claim_demo_requests. */
+export const claimPending = async (
+  workerId: string,
+  batch: number
+): Promise<DemoRequestRow[]> => {
+  const { data, error } = await client().rpc('claim_demo_requests', {
+    p_worker: workerId,
+    p_batch: batch
+  })
+  if (error) throw new Error(`Failed to claim demo requests: ${error.message}`)
+  return (data ?? []) as DemoRequestRow[]
+}
+
+/* Rows whose worker died mid-job sit in 'processing' forever. Returns those with
+ * retries left to 'pending' and marks the exhausted ones 'failed'. */
+export const reapStale = async (): Promise<DemoRequestRow[]> => {
+  const { data, error } = await client().rpc('reap_stale_demo_requests', {
+    p_stale_minutes: env.queueStaleMinutes
+  })
+  if (error) throw new Error(`Failed to reap stale requests: ${error.message}`)
+  return (data ?? []) as DemoRequestRow[]
+}
+
+const update = async (
+  id: string,
+  patch: Partial<DemoRequestRow>
+): Promise<void> => {
+  const { error } = await client()
+    .from('demo_requests')
+    .update(patch)
+    .eq('id', id)
+  if (error) {
+    throw new Error(`Failed to update demo request ${id}: ${error.message}`)
+  }
+}
+
+/* Persisted before the pipeline runs so a retry reuses the same id, rather than
+ * orphaning the previous attempt's S3 objects and Upstash namespace. */
+export const setCompanyId = (id: string, companyId: string): Promise<void> =>
+  update(id, { company_id: companyId })
+
+export const setDemoUrl = (id: string, demoUrl: string): Promise<void> =>
+  update(id, { demo_url: demoUrl })
+
+export const markComplete = (id: string): Promise<void> =>
+  update(id, { status: 'complete', completed_at: new Date().toISOString() })
+
+/* `exhausted` rows stay failed; the rest go back to pending for another pass.
+ * Note attempts was already incremented by the claim, so the worker compares
+ * row.attempts >= row.max_attempts to decide.
+ *
+ * claimed_at/claimed_by are left as-is: the next claim overwrites them, and the
+ * reaper only considers rows still in 'processing'. */
+export const markFailed = (
+  id: string,
+  error: string,
+  exhausted: boolean
+): Promise<void> =>
+  update(id, {
+    status: exhausted ? 'failed' : 'pending',
+    last_error: error.slice(0, 2000)
+  })
+
+/* Called on graceful shutdown so in-flight rows are immediately reclaimable
+ * instead of waiting out DEMO_STALE_MINUTES. Refunds the attempt the claim
+ * consumed — a clean restart shouldn't count against a request's retries. */
+export const releaseClaims = async (ids: string[]): Promise<void> => {
+  if (ids.length === 0) return
+  const { error } = await client().rpc('release_demo_requests', { p_ids: ids })
+  if (error) throw new Error(`Failed to release claims: ${error.message}`)
+}

--- a/apps/demo-setup/src/queue/worker.ts
+++ b/apps/demo-setup/src/queue/worker.ts
@@ -1,0 +1,207 @@
+import { hostname } from 'node:os'
+import { env } from '../config/env'
+import { logger } from '../lib/logger'
+import { deriveCompanyId } from '../lib/slug'
+import { killActiveCrawls } from '../integrations/crawler'
+import { sendDemoReadyEmail, sendInternalAlert } from '../integrations/sendgrid'
+import { runPipeline } from '../pipeline/run-pipeline'
+import {
+  claimPending,
+  markComplete,
+  markFailed,
+  reapStale,
+  releaseClaims,
+  setCompanyId,
+  setDemoUrl
+} from './repo'
+import type { DemoRequestRow } from '../types'
+
+const WORKER_ID = `${hostname()}:${process.pid}`
+
+// Reaping is cheap but pointless every tick; roughly once a minute is plenty.
+const REAP_EVERY_N_TICKS = 6
+
+/* Rows we currently hold, so shutdown can hand them back rather than leaving
+ * them to time out via DEMO_STALE_MINUTES. */
+const inFlight = new Set<string>()
+let stopping = false
+let timer: NodeJS.Timeout | undefined
+let ticks = 0
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)
+
+const processRequest = async (row: DemoRequestRow): Promise<void> => {
+  // Reuse the id from a previous attempt; a fresh slug would orphan that
+  // attempt's S3 objects and Upstash namespace.
+  const companyId = row.company_id ?? deriveCompanyId(row.company_name)
+  if (!row.company_id) await setCompanyId(row.id, companyId)
+
+  const { demoUrl, crawlDone } = await runPipeline({
+    companyId,
+    companyName: row.company_name,
+    companyWebsite: row.website_url,
+    companyEmail: row.contact_email,
+    isProd: row.is_prod
+  })
+  await setDemoUrl(row.id, demoUrl)
+
+  // The demo is live and branded now, but its RAG namespace is empty until the
+  // crawl lands. Emailing before this resolves sends the prospect to a chatbot
+  // that can't answer anything about them.
+  await crawlDone
+
+  const sent = await sendDemoReadyEmail({ to: row.delivery_email, companyId })
+  await markComplete(row.id)
+
+  if (!sent) {
+    // The demo itself is fine — retrying would burn the LLM spend again for
+    // nothing. Flag it so a human can forward the link.
+    logger.error(`Demo ${companyId} built but the email failed to send`)
+    await sendInternalAlert({
+      subject: `[demo-setup] Built ${companyId} but could not email ${row.delivery_email}`,
+      body: `The demo is live at ${demoUrl} but SendGrid rejected the notification. Forward it manually.`
+    })
+  }
+}
+
+const handleFailure = async (row: DemoRequestRow, error: unknown) => {
+  // A shutdown kills in-flight crawls, which surfaces here as a rejection. That
+  // isn't a real failure — releaseClaims() hands the row back and refunds the
+  // attempt, so don't also charge it one via markFailed.
+  if (stopping) return
+
+  const message = errorMessage(error)
+  // `attempts` was already incremented when the row was claimed.
+  const exhausted = row.attempts >= row.max_attempts
+  logger.error(
+    `Demo request ${row.id} failed (attempt ${row.attempts}/${row.max_attempts}):`,
+    message
+  )
+
+  try {
+    await markFailed(row.id, message, exhausted)
+  } catch (updateError) {
+    // Losing the DB here means the row stays 'processing' until the reaper
+    // notices. Log loudly rather than crashing the worker loop.
+    logger.error(`Could not record failure for ${row.id}:`, updateError)
+    return
+  }
+
+  if (exhausted) {
+    await sendInternalAlert({
+      subject: `[demo-setup] Demo request failed after ${row.max_attempts} attempts`,
+      body: [
+        `Company: ${row.company_name}`,
+        `Website: ${row.website_url}`,
+        `Delivery email: ${row.delivery_email}`,
+        `Request id: ${row.id}`,
+        '',
+        `Last error: ${message}`
+      ].join('\n')
+    })
+  }
+}
+
+const tick = async (): Promise<void> => {
+  if (stopping) return
+
+  if (ticks++ % REAP_EVERY_N_TICKS === 0) {
+    try {
+      const reaped = await reapStale()
+      if (reaped.length > 0) {
+        logger.warn(`Reaped ${reaped.length} stale demo request(s)`)
+      }
+    } catch (error) {
+      logger.error('Reap failed:', error)
+    }
+  }
+
+  const free = env.queueConcurrency - inFlight.size
+  if (free <= 0) return
+
+  let rows: DemoRequestRow[]
+  try {
+    rows = await claimPending(WORKER_ID, free)
+  } catch (error) {
+    // Transient Supabase blip. Next tick tries again.
+    logger.error('Claim failed:', error)
+    return
+  }
+
+  for (const row of rows) {
+    inFlight.add(row.id)
+    logger.info(`Claimed demo request ${row.id} for ${row.company_name}`)
+
+    // Not awaited: the loop must stay free to fill the other concurrency slots.
+    // Nothing may escape this IIFE — an unhandled rejection would kill the
+    // process and strand every other in-flight row.
+    void (async () => {
+      try {
+        await processRequest(row)
+      } catch (error) {
+        try {
+          await handleFailure(row, error)
+        } catch (failureError) {
+          logger.error(`Failure handling threw for ${row.id}:`, failureError)
+        }
+      } finally {
+        inFlight.delete(row.id)
+      }
+    })()
+  }
+}
+
+/* Polls demo_requests, claims what it can hold, and runs each to completion.
+ *
+ * Runs in the same process as the Express app — pm2 already supervises it, and
+ * the pipeline shells out to Python on this machine anyway. */
+export const startWorker = (): void => {
+  if (!env.queueEnabled) {
+    logger.info('Demo request queue disabled (DEMO_QUEUE_ENABLED=false)')
+    return
+  }
+
+  // The reaper must not be able to steal a row from a worker that is merely
+  // slow. Worst case a job takes scrape + crawl plus the LLM calls between them.
+  const worstCaseMs = env.scrapeTimeoutMs + env.crawlTimeoutMs
+  if (env.queueStaleMinutes * 60_000 <= worstCaseMs) {
+    throw new Error(
+      `DEMO_STALE_MINUTES (${env.queueStaleMinutes}m) must exceed SCRAPE_TIMEOUT_MS + CRAWL_TIMEOUT_MS ` +
+        `(${Math.ceil(worstCaseMs / 60_000)}m), or the reaper will reclaim rows a healthy worker still holds.`
+    )
+  }
+
+  logger.info(
+    `Demo request worker ${WORKER_ID} polling every ${env.queuePollIntervalMs}ms, concurrency ${env.queueConcurrency}`
+  )
+
+  const schedule = () => {
+    timer = setTimeout(async () => {
+      await tick()
+      if (!stopping) schedule()
+    }, env.queuePollIntervalMs)
+  }
+  schedule()
+}
+
+/* Stops claiming, kills in-flight crawls, and hands their rows back so another
+ * process (or this one after restart) picks them up immediately. */
+export const stopWorker = async (): Promise<void> => {
+  if (stopping) return
+  stopping = true
+  if (timer) clearTimeout(timer)
+
+  killActiveCrawls()
+
+  const held = [...inFlight]
+  if (held.length === 0) return
+
+  logger.info(`Releasing ${held.length} in-flight demo request(s)`)
+  try {
+    await releaseClaims(held)
+  } catch (error) {
+    // The reaper will recover these after DEMO_STALE_MINUTES.
+    logger.error('Failed to release claims on shutdown:', error)
+  }
+}

--- a/apps/demo-setup/src/types.ts
+++ b/apps/demo-setup/src/types.ts
@@ -60,3 +60,28 @@ export type BrandResult = {
   brandColor: string
   fontFamily: string
 }
+
+/* A row of the demo_requests queue, written by the marketing site's /api/demo
+ * and claimed by the worker. Mirrors the migration in
+ * apps/backend/supabase/migrations/20260708000000_add_demo_requests_table.sql */
+export type DemoRequestRow = {
+  id: string
+  website_url: string
+  company_name: string
+  contact_email: string
+  delivery_email: string
+  source_path: string | null
+  user_agent: string | null
+  company_id: string | null
+  demo_url: string | null
+  is_prod: boolean
+  status: 'pending' | 'processing' | 'complete' | 'failed'
+  attempts: number
+  max_attempts: number
+  last_error: string | null
+  claimed_at: string | null
+  claimed_by: string | null
+  completed_at: string | null
+  created_at: string
+  updated_at: string | null
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       '@dialogue-foundry/tsconfig':
         specifier: workspace:*
         version: link:../../packages/tsconfig
+      '@sendgrid/mail':
+        specifier: ^8.1.5
+        version: 8.1.5
       '@supabase/supabase-js':
         specifier: ^2.49.1
         version: 2.49.4


### PR DESCRIPTION
## Context

Prospects submit a form on untap-ai.com. An n8n workflow used to pick that up and orchestrate the demo build. This replaces it: the marketing site inserts a row into a new `demo_requests` table, and demo-setup polls it, claims rows, builds each demo, waits for its RAG crawl, and emails the link.

A **pulled** queue rather than an exposed endpoint, because the mac-mini this runs on has no public ingress — and the row doubles as a durable job record surviving pm2 restarts and reboots.

```
untap-ai.com/try ──► Next /api/demo ──► supabase.demo_requests (pending)
                                              ▲ claim_demo_requests()
                                              │ FOR UPDATE SKIP LOCKED
                                    mac-mini worker (concurrency 2)
                                              │ pipeline → demoUrl
                                              │ await crawl (timeout + SIGKILL)
                                              │ SendGrid → delivery_email
                                              ▼
                                        status=complete
```

## ⚠️ Merge order & deploy state

- The `demo_requests` migration is **already applied to prod** (see Testing). Merging this is safe.
- **Merge this before [Untap-website#10](https://github.com/Untap-AI/Untap-website/pull/10)**, so the worker is polling before the form starts enqueuing.
- Depends on [web-crawler#15](https://github.com/Untap-AI/web-crawler/pull/15).
- `pm2 demo-setup` is currently **stopped** on the mac-mini. Starting it before the website merges is a no-op (empty queue).
- New env vars needed in `apps/demo-setup/.env`: `SENDGRID_API_KEY` (set), plus optional `DEMO_*` / `*_TIMEOUT_MS` tuning. See `.env.example`.

## Queue design

`FOR UPDATE SKIP LOCKED` is what makes a concurrent claim atomic; it can't be expressed through PostgREST, which is the only reason these are functions.

**All three functions are `SECURITY INVOKER`, with `EXECUTE` revoked from `PUBLIC`/`anon`/`authenticated` and granted explicitly to `service_role`.** The existing `is_admin()`/`user_company_ids()` need `DEFINER` because they run inside RLS policies and read `dashboard_users`; that reason does not transfer here. The caller already holds the service key, which bypasses RLS — so `DEFINER` would buy nothing, and since Supabase exposes every `public` function as an RPC endpoint, it would let anyone with the **public anon key** call `claim_demo_requests('x', 100000)` and starve the worker.

Note that revoking from `PUBLIC` also revokes from `service_role`, which inherits it — hence the explicit re-grant.

`reap_stale_demo_requests` (worker died) **consumes** an attempt; `release_demo_requests` (graceful shutdown) **refunds** it. Deliberate asymmetry: a clean SIGTERM shouldn't count against retries, but a URL that reliably kills the worker must exhaust them rather than crash-loop forever.

RLS is enabled with **no policies** — the earlier `remote_schema` dump blanket-grants DML to `anon`, so RLS is the only gate on this table.

## Worker

- Concurrency 2, FIFO. Refuses to boot if `DEMO_STALE_MINUTES` is short enough that the reaper could steal a row from a healthy worker.
- **The demo-ready email is sent only after the crawl seeds the RAG namespace.** The widget is live and branded before that but knows nothing about the company; an early email sends the prospect to a chatbot that can't answer.
- On failure the prospect is **never** emailed — the team is alerted once retries are exhausted. A transient LLM 429 must not become a bad customer touch.

## Crawl subprocesses

- `startCrawl` → `runCrawl`: awaitable, bounded by `CRAWL_TIMEOUT_MS`. Same for the scrape, which is awaited inline and would otherwise pin a worker slot.
- **Both spawn `detached` and are killed by process group.** `orchestrator.py` launches Chrome via Playwright, so signalling only the Python pid orphaned those browsers — that's why crawls lingered for hours in `CLOSE_WAIT`. Verified: `child.kill()` leaves the grandchild alive; the process-group kill reaps it.
- Upstash/OpenAI config resolves *before* anything is published. It was read inside `startCrawl`, so a missing var turned an already-live demo into a 500.
- pm2 `max_memory_restart` 512M → 2G: two concurrent demos mean up to four Chromium trees, and a restart kills in-flight crawls.

## Company id namespacing

`demo-<slug>-<8 hex>`. Without the prefix a prospect named "Acme" slugs to `acme`, and the pipeline's upsert into `companies`/`chat_configs` would **overwrite a real customer's system prompt and vector namespace**.

The suffix is 32 bits, not 16, because a collision is not a retry: the second demo upserts over the first's config and S3 objects, leaving the first prospect's link serving someone else's company. Names are accent-folded (`Straße GmbH` → `demo-strasse-gmbh-…`) since the slug *is* the URL the prospect clicks — the SendGrid template builds it from `company_id`.

## Also included

Two fixes from the earlier manual test of this pipeline, in files this PR rewrites anyway: `API_BASE_URL_PROD` was missing the `/api` suffix the widget expects, and the background crawl inherited an `EXPECTED_CHUNKS` tuned for a different workflow, silently skipping every upload.

## Testing

**Migration** — dry-run against prod inside a transaction, then rolled back; then applied for real inside a transaction. Schema diffed against a pre-migration baseline: **0 columns removed, 0 changes outside `demo_requests`, 0 existing functions modified**; `chats`/`messages`/`companies`/`chat_configs`/`analytics_events` untouched. Verified idempotent (applies twice cleanly) and that the prerequisite guard fires when `update_updated_at_column()` is absent.

**Security, on live prod** — by `SET ROLE`, `anon` and `authenticated` get `permission denied` on the table and on all three functions; `service_role` works. RLS on, 0 policies, all functions `prosecdef=false`.

**Concurrency** — two simultaneous transactions calling `claim_demo_requests`: the second skipped the locked rows rather than blocking or double-claiming.

**End-to-end against prod** — inserted one row for `untap-ai.com`. Worker claimed it, slugged `demo-untap-ai-50f41a55`, built and uploaded the demo, crawled 20 vectors into `demo-untap-ai-50f41a55-df`, emailed the link, and marked `complete` in ~2 min on one attempt. Opened the emailed link in a real browser: HTTP 200, correct branding, and the widget answered *"What pricing plans does Untap AI offer?"* with the real plans from the crawled site, zero console errors. **Zero orphaned Python or Chrome processes afterward.**

Also: `tsc` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)