### PR TITLE
feat(demo-setup): rework brand detection for accurate colors, logos, and email

### DIFF
--- a/apps/demo-setup/package.json
+++ b/apps/demo-setup/package.json
@@ -22,6 +22,8 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
+    "node-vibrant": "^4.0.4",
+    "sharp": "^0.35.3",
     "zod": "^4.1.8"
   },
   "devDependencies": {

--- a/apps/demo-setup/src/config/env.ts
+++ b/apps/demo-setup/src/config/env.ts
@@ -33,11 +33,12 @@ export const env = {
     .filter(Boolean),
 
   anthropicApiKey: () => required('ANTHROPIC_API_KEY'),
-  // Fast/cheap extraction model for content analysis + brand selection.
-  modelAnalysis: optional('MODEL_ANALYSIS', 'claude-haiku-4-5'),
-  // The generative copy step (welcome message + suggestions) can use a stronger
-  // model for a quality bump; defaults to the same cheap model.
-  modelBrand: optional('MODEL_BRAND', 'claude-haiku-4-5'),
+  // Generates the welcome message + suggestions — the first thing a prospect
+  // reads, so quality matters more than the cost delta of one call per demo.
+  modelAnalysis: optional('MODEL_ANALYSIS', 'claude-sonnet-5'),
+  // Vision call that picks the brand color/logo out of a screenshot. Also one
+  // call per demo; vision quality directly determines whether colors match.
+  modelBrand: optional('MODEL_BRAND', 'claude-sonnet-5'),
 
   // The background crawl (orchestrator.py) still uses OpenAI internally for
   // content filtering/summarization — unrelated to this service's own Claude
@@ -80,23 +81,35 @@ export const env = {
         )
       : optional(
           'API_BASE_URL_TEST',
-          'https://dialogue-foundry-backend-smokebox-swjv.onrender.com/api'
+          'https://dialogue-foundry-backend-v2-test.onrender.com/api'
         ),
 
   crawlerDir: () => required('CRAWLER_DIR'),
   crawlerPython: optional('CRAWLER_PYTHON', 'python3'),
   crawlerMaxDepth: (isProd: boolean) =>
     isProd
-      ? optional('CRAWLER_MAX_DEPTH_PROD', '0')
-      : optional('CRAWLER_MAX_DEPTH_TEST', '0'),
+      ? optional('CRAWLER_MAX_DEPTH_PROD', '1')
+      : optional('CRAWLER_MAX_DEPTH_TEST', '1'),
+  // Hard cap on pages visited by the deep RAG crawl. Depth alone isn't a bound —
+  // depth 1 on a site with a large footer nav could otherwise be hundreds of
+  // pages.
+  crawlerMaxPages: optional('CRAWLER_MAX_PAGES', '100'),
 
-  // Number of pages the demo-prep scrape reads for content analysis.
-  scrapeMaxPages: optional('SCRAPE_MAX_PAGES', '5'),
+  // Number of pages the shallow demo-prep scrape fetches (homepage + internal
+  // links, ranked by relevance — see web-crawler/scrape_page.py's PATH_PRIORITIES).
+  scrapeMaxPages: optional('SCRAPE_MAX_PAGES', '8'),
+  // How many of those scraped pages get fed to the content-analysis LLM call.
+  // Kept as its own knob (rather than reusing scrapeMaxPages) since a much
+  // larger scrape shouldn't necessarily balloon the prompt.
+  analysisMaxPages: optionalInt('ANALYSIS_MAX_PAGES', 8),
 
   // Hard bounds on the two Python subprocesses. Both spawn Chrome, and a hung
-  // browser would otherwise pin a queue worker slot forever.
+  // browser would otherwise pin a queue worker slot forever. Sized for a depth-1
+  // / 100-page crawl parallelized per Phase 3 (~6-8min in practice); the 5min
+  // fixed LLM-call budget between them is accounted for by the assertion in
+  // queue/worker.ts, not by these values themselves.
   scrapeTimeoutMs: optionalInt('SCRAPE_TIMEOUT_MS', 5 * 60 * 1000),
-  crawlTimeoutMs: optionalInt('CRAWL_TIMEOUT_MS', 15 * 60 * 1000),
+  crawlTimeoutMs: optionalInt('CRAWL_TIMEOUT_MS', 20 * 60 * 1000),
 
   /* ---- Demo request queue (Supabase table polled by the worker) ---- */
   // The queue always lives in the prod project, independent of a row's is_prod
@@ -111,7 +124,7 @@ export const env = {
   // A row claimed longer than this is assumed dead (pm2 restart, reboot, OOM)
   // and is returned to the queue. Must exceed scrape + crawl timeouts combined,
   // or the reaper will steal rows out from under a healthy worker.
-  queueStaleMinutes: optionalInt('DEMO_STALE_MINUTES', 30),
+  queueStaleMinutes: optionalInt('DEMO_STALE_MINUTES', 45),
 
   /* ---- SendGrid (demo-ready notification) ---- */
   // Optional: unset means email is skipped with a warning, so `POST /demos` and

--- a/apps/demo-setup/src/integrations/crawler.ts
+++ b/apps/demo-setup/src/integrations/crawler.ts
@@ -36,6 +36,7 @@ export const runCrawl = (input: PreparedInput): Promise<void> =>
         ...process.env,
         START_URLS: input.companyWebsite,
         MAX_DEPTH: env.crawlerMaxDepth(input.isProd),
+        MAX_PAGES: env.crawlerMaxPages,
         UPSTASH_VECTOR_REST_URL: upstash.url,
         UPSTASH_VECTOR_REST_TOKEN: upstash.token,
         UPSTASH_NAMESPACE: input.namespace,

--- a/apps/demo-setup/src/integrations/email-templates.ts
+++ b/apps/demo-setup/src/integrations/email-templates.ts
@@ -1,0 +1,111 @@
+/* The "demo ready" email used to live entirely as a SendGrid dynamic template
+ * (d-75e4a3c87e304f638c01730516bc9396), which only ever received `company_id`
+ * and built both the primary and secondary demo links itself — a second link
+ * to a widget variant nothing else in this codebase ever decided between.
+ * Now that detectBrand picks a single theme per demo (see pickTheme in
+ * detect-brand.ts), there's exactly one link to send, and keeping the markup
+ * here means it's readable, diffable, and testable like the rest of the
+ * pipeline instead of being an opaque reference to an ID in SendGrid's UI. */
+
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+
+export const DEMO_READY_SUBJECT = 'Your Personalized Demo is Ready!'
+
+export const renderDemoReadyEmail = ({ demoUrl }: { demoUrl: string }): { html: string; text: string } => {
+  const safeUrl = escapeHtml(demoUrl)
+  const displayUrl = demoUrl.replace(/^https?:\/\//, '')
+
+  const html = `<html lang="en">
+  <body style="font-family: Arial, sans-serif; color: #222;">
+    <p>
+      Thank you for your interest in <strong>Untap AI!</strong> We've prepared your personalized AI assistant demo as requested.
+    </p>
+    <p>
+      <strong>Your live demo:</strong>
+      <a href="${safeUrl}" style="color: #2563eb; text-decoration: underline;">
+        ${escapeHtml(displayUrl)}
+      </a>
+    </p>
+    <p>
+      The AI assistant is trained on your website and acts as your instant customer support rep, ready to answer questions and capture inbound leads.
+    </p>
+    <p>
+      If you'd like a walkthrough, have questions, or want to talk about next steps, just reply to this email. Our team (cc'd) can quickly hop on a call or customize the solution further for your needs.
+    </p>
+    <p>
+      Thanks again for considering Untap AI.<br>
+      <strong>The Untap AI Team</strong>
+    </p>
+  </body>
+</html>`
+
+  const text = `Thank you for your interest in Untap AI! We've prepared your personalized AI assistant demo as requested.
+
+Your live demo: ${demoUrl}
+
+The AI assistant is trained on your website and acts as your instant customer support rep, ready to answer questions and capture inbound leads.
+
+If you'd like a walkthrough, have questions, or want to talk about next steps, just reply to this email. Our team (cc'd) can quickly hop on a call or customize the solution further for your needs.
+
+Thanks again for considering Untap AI.
+The Untap AI Team`
+
+  return { html, text }
+}
+
+/* Sent the moment a request is claimed off the queue — before the site's even
+ * scraped, let alone branded — so a prospect isn't left wondering whether
+ * their submission went anywhere during the ~30 minute build. */
+export const DEMO_PENDING_SUBJECT = 'Your Personalized Demo is Being Created'
+
+export const renderDemoPendingEmail = ({ companyName }: { companyName: string }): { html: string; text: string } => {
+  const safeName = escapeHtml(companyName)
+
+  const html = `<div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+  <h2 style="color: #465cff; margin-bottom: 20px;">Your Personalized Demo is Being Created</h2>
+
+  <p style="margin-bottom: 15px;">Hi there!</p>
+
+  <p style="margin-bottom: 15px;">We've received your request for a personalized demo for <strong>${safeName}</strong>.</p>
+
+  <p style="margin-bottom: 15px;">Our team is now training your AI assistant on your website's content and styling it to match your brand. This usually takes about <strong>30 minutes</strong>.</p>
+
+  <p style="margin-bottom: 15px;">You'll receive another email with your private demo link once it's ready.</p>
+
+  <p style="margin-bottom: 15px;">In the meantime, feel free to explore our <a href="https://untap-ai.com/pricing" style="color: #465cff; text-decoration: none;">pricing plans</a> or reach out with any questions.</p>
+
+  <p style="margin-bottom: 20px;">
+    Best regards,<br>
+    The Untap AI Team
+  </p>
+
+  <hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;">
+
+  <p style="color: #666; font-size: 14px; margin: 0;">
+    Questions? Reply to this email or contact us at
+    <a href="mailto:contact@untap-ai.com" style="color: #465cff; text-decoration: none;">contact@untap-ai.com</a>
+  </p>
+</div>`
+
+  const text = `Hi there!
+
+We've received your request for a personalized demo for ${companyName}.
+
+Our team is now training your AI assistant on your website's content and styling it to match your brand. This usually takes about 30 minutes.
+
+You'll receive another email with your private demo link once it's ready.
+
+In the meantime, feel free to explore our pricing plans (https://untap-ai.com/pricing) or reach out with any questions.
+
+Best regards,
+The Untap AI Team
+
+Questions? Reply to this email or contact us at contact@untap-ai.com`
+
+  return { html, text }
+}

--- a/apps/demo-setup/src/integrations/s3.ts
+++ b/apps/demo-setup/src/integrations/s3.ts
@@ -21,17 +21,12 @@ const putHtml = (key: string, body: string): Promise<unknown> =>
     })
     .promise()
 
-/* Uploads the primary and secondary demo pages to the demo bucket at
- * {companyId}/index.html and {companyId}/secondary/index.html. Returns the
- * public demo URL. */
-export const uploadDemo = async (
-  companyId: string,
-  html: { primary: string; secondary: string }
-): Promise<string> => {
-  await Promise.all([
-    putHtml(`${companyId}/index.html`, html.primary),
-    putHtml(`${companyId}/secondary/index.html`, html.secondary)
-  ])
+/* Uploads the demo page to the demo bucket at {companyId}/index.html. Returns
+ * the public demo URL. detectBrand already picked which widget theme this
+ * demo ships with, so there's exactly one page to upload — no unused
+ * "secondary" variant sitting around for nobody to link to. */
+export const uploadDemo = async (companyId: string, html: string): Promise<string> => {
+  await putHtml(`${companyId}/index.html`, html)
 
   const demoUrl = `${env.demoBaseUrl}/${companyId}/`
   logger.info(`Uploaded demo to ${demoUrl}`)

--- a/apps/demo-setup/src/integrations/scraper.ts
+++ b/apps/demo-setup/src/integrations/scraper.ts
@@ -2,9 +2,22 @@ import { spawn } from 'node:child_process'
 import { env } from '../config/env'
 import { logger } from '../lib/logger'
 import { killProcessTree } from '../lib/process-tree'
+import type { BrandProbe } from '../types'
 
 export type ScrapedPage = { url: string; markdown: string }
-export type ScrapeResult = { pages: ScrapedPage[]; homepageHtml: string }
+export type ScrapeResult = {
+  pages: ScrapedPage[]
+  homepageHtml: string
+  /* Computed-style brand signals read out of the live page. `{}` when the probe
+   * couldn't run — callers must fall back to parsing homepageHtml. */
+  brand: BrandProbe
+  /* Base64 JPEG of the homepage above the fold, or '' if capture failed. */
+  screenshot: string
+  // Pixel dimensions of `screenshot` — needed to convert the vision model's
+  // percentage-based logo bounding box back into page pixel coordinates.
+  screenshotWidth: number
+  screenshotHeight: number
+}
 
 /* Runs the local crawl4ai scrape entrypoint (web-crawler/scrape_page.py) as a
  * subprocess and returns its JSON payload. This replaces the old Tavily crawl +

--- a/apps/demo-setup/src/integrations/sendgrid.ts
+++ b/apps/demo-setup/src/integrations/sendgrid.ts
@@ -1,11 +1,13 @@
 import sgMail from '@sendgrid/mail'
 import { env } from '../config/env'
 import { logger } from '../lib/logger'
+import {
+  DEMO_PENDING_SUBJECT,
+  DEMO_READY_SUBJECT,
+  renderDemoPendingEmail,
+  renderDemoReadyEmail
+} from './email-templates'
 
-/* Ported verbatim from the SendGrid node of the n8n workflow this service
- * replaces. The template renders the demo link itself from company_id, so
- * company_id is the only dynamic field it needs. */
-const DEMO_READY_TEMPLATE_ID = 'd-75e4a3c87e304f638c01730516bc9396'
 const FROM = { email: 'demo@untap-ai.com', name: 'Untap AI' } as const
 const INTERNAL_CC = [
   { email: 'james@untap-ai.com' },
@@ -34,10 +36,12 @@ const client = (): typeof sgMail | undefined => {
  * caller records the boolean so a missed email is visible in the queue row. */
 export const sendDemoReadyEmail = async ({
   to,
-  companyId
+  companyId,
+  demoUrl
 }: {
   to: string
   companyId: string
+  demoUrl: string
 }): Promise<boolean> => {
   const mail = client()
   if (!mail) {
@@ -47,17 +51,16 @@ export const sendDemoReadyEmail = async ({
     return false
   }
 
+  const { html, text } = renderDemoReadyEmail({ demoUrl })
+
   try {
     await mail.send({
-      personalizations: [
-        {
-          to: [{ email: to }],
-          cc: INTERNAL_CC,
-          dynamicTemplateData: { company_id: companyId }
-        }
-      ],
+      to,
+      cc: INTERNAL_CC,
       from: FROM,
-      templateId: DEMO_READY_TEMPLATE_ID
+      subject: DEMO_READY_SUBJECT,
+      html,
+      text
     })
     logger.info(`Demo-ready email sent to ${to} for ${companyId}`)
     return true
@@ -65,6 +68,48 @@ export const sendDemoReadyEmail = async ({
     logger.error(`Failed to send demo-ready email for ${companyId}:`, error)
     // SendGrid puts the actionable detail (bad template id, unverified sender)
     // in the response body, not the Error message.
+    const body = (error as { response?: { body?: unknown } }).response?.body
+    if (body) logger.error('SendGrid response body:', JSON.stringify(body))
+    return false
+  }
+}
+
+/* Sent immediately on claiming a request — before scraping, branding, or
+ * crawling have even started — so a prospect isn't left wondering whether
+ * their submission went anywhere during the build. Not CC'd to the team;
+ * it's a receipt, not a milestone worth their attention. Same never-throws
+ * contract as sendDemoReadyEmail. */
+export const sendDemoPendingEmail = async ({
+  to,
+  companyId,
+  companyName
+}: {
+  to: string
+  companyId: string
+  companyName: string
+}): Promise<boolean> => {
+  const mail = client()
+  if (!mail) {
+    logger.warn(
+      `SENDGRID_API_KEY unset — skipping demo-pending email to ${to} for ${companyId}`
+    )
+    return false
+  }
+
+  const { html, text } = renderDemoPendingEmail({ companyName })
+
+  try {
+    await mail.send({
+      to,
+      from: FROM,
+      subject: DEMO_PENDING_SUBJECT,
+      html,
+      text
+    })
+    logger.info(`Demo-pending email sent to ${to} for ${companyId}`)
+    return true
+  } catch (error) {
+    logger.error(`Failed to send demo-pending email for ${companyId}:`, error)
     const body = (error as { response?: { body?: unknown } }).response?.body
     if (body) logger.error('SendGrid response body:', JSON.stringify(body))
     return false

--- a/apps/demo-setup/src/lib/color.ts
+++ b/apps/demo-setup/src/lib/color.ts
@@ -1,0 +1,44 @@
+export type Rgb = { r: number; g: number; b: number }
+
+export const parseRgb = (value: string): Rgb | null => {
+  const hex = value.match(/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/)
+  if (hex) {
+    const h = hex[1].length === 3 ? [...hex[1]].map(c => c + c).join('') : hex[1]
+    return {
+      r: parseInt(h.slice(0, 2), 16),
+      g: parseInt(h.slice(2, 4), 16),
+      b: parseInt(h.slice(4, 6), 16)
+    }
+  }
+  const rgb = value.match(/^rgba?\(\s*(\d+)[,\s]+(\d+)[,\s]+(\d+)/i)
+  if (rgb) return { r: +rgb[1], g: +rgb[2], b: +rgb[3] }
+  return null
+}
+
+export const toHex = ({ r, g, b }: Rgb): string =>
+  '#' +
+  [r, g, b]
+    .map(n => Math.round(Math.min(255, Math.max(0, n))).toString(16).padStart(2, '0'))
+    .join('')
+
+/* WCAG 2.1 relative luminance. */
+export const luminance = ({ r, g, b }: Rgb): number => {
+  const channel = (value: number): number => {
+    const c = value / 255
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+  }
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+}
+
+/* WCAG 2.1 contrast ratio between two relative luminances — 1 (identical) to
+ * 21 (black on white). The two-luminance form is the primitive; contrastRatio
+ * below is just it applied to two colors. */
+export const contrastFromLuminances = (l1: number, l2: number): number => {
+  const lighter = Math.max(l1, l2)
+  const darker = Math.min(l1, l2)
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+/* WCAG 2.1 contrast ratio between two colors — 1 (identical) to 21 (black on white). */
+export const contrastRatio = (a: Rgb, b: Rgb): number =>
+  contrastFromLuminances(luminance(a), luminance(b))

--- a/apps/demo-setup/src/pipeline/analyze-content.ts
+++ b/apps/demo-setup/src/pipeline/analyze-content.ts
@@ -39,22 +39,38 @@ const analysisSchema = jsonSchema<ContentAnalysis>({
       description:
         'The primary contact phone number, or empty string if none found'
     },
+    /* Rendered through Streamdown (see apps/frontend/src/components/response.tsx),
+     * so markdown formats correctly — but the widget is a narrow column, and a
+     * heading or a bulleted list reads as clutter in a greeting. */
     welcomeMessage: {
       type: 'string',
       description:
-        'A warm, energetic, second-person greeting for a website chat widget. Mention the company name once. Max 60 words. Use \\n for line breaks.'
+        'A chat-widget greeting in GitHub-flavored markdown. Exactly two parts, separated by a blank line: (1) one short bold opening line that names the company, e.g. "**Welcome to Acme Roofing!**", and (2) a single sentence, in second person, saying what you can help the visitor with — grounded in what this business actually offers. No headings, no lists, no links, no emoji. Under 40 words total.'
     },
     suggestions: {
       type: 'array',
       minItems: 4,
       maxItems: 4,
       description:
-        'Four full questions a customer would typically ask, each max 10 words',
+        'Four starter questions a real customer would ask this specific business. Each must be answerable from the website content above — never invent a service, product, policy, or location that is not present in the content. Cover four different topics.',
       items: {
         type: 'object',
         additionalProperties: false,
-        required: ['prompt'],
-        properties: { prompt: { type: 'string' } }
+        required: ['label', 'prompt'],
+        properties: {
+          /* The widget renders `suggestion.label || suggestion.prompt` inside a
+           * ~140px button. A full question wraps to four cramped lines. */
+          label: {
+            type: 'string',
+            description:
+              'Button text for this question: 2-4 words, Title Case, no punctuation. Must read clearly in a narrow 140px button. Example: "Wedding Venues".'
+          },
+          prompt: {
+            type: 'string',
+            description:
+              'The full question the button asks, phrased in the customer\'s own voice. Max 12 words. Example: "Do you host weddings, and what does it cost?"'
+          }
+        }
       }
     }
   }
@@ -66,13 +82,13 @@ const analysisSchema = jsonSchema<ContentAnalysis>({
 export const analyzeContent = async (
   pages: string[]
 ): Promise<ContentAnalysis> => {
-  const content = pages.slice(0, 5).join('\n\n---\n\n')
+  const content = pages.slice(0, env.analysisMaxPages).join('\n\n---\n\n')
 
   const { object } = await generateObject({
     model: anthropic(env.modelAnalysis),
     schema: analysisSchema,
     system:
-      'You extract business details from website content for a customer-facing chat widget. Use only information present in the content, and use the business name exactly as it appears on the site.',
+      'You extract business details from website content for a customer-facing chat widget. Use only information present in the content, and use the business name exactly as it appears on the site. Never invent facts the content does not state.',
     prompt: `Website content:\n\n${content}`
   })
 

--- a/apps/demo-setup/src/pipeline/build-html.ts
+++ b/apps/demo-setup/src/pipeline/build-html.ts
@@ -8,8 +8,8 @@ const buildStyles = (input: PreparedInput, brand: BrandResult) => {
     primaryColor: input.styles?.primaryColor || brand.brandColor,
     fontFamily: input.styles?.fontFamily || brand.fontFamily
   }
-  if (input.styles?.secondaryColor)
-    styles.secondaryColor = input.styles.secondaryColor
+  const secondaryColor = input.styles?.secondaryColor || brand.secondaryColor
+  if (secondaryColor) styles.secondaryColor = secondaryColor
   if (input.styles?.backgroundColor)
     styles.backgroundColor = input.styles.backgroundColor
   return styles
@@ -18,8 +18,7 @@ const buildStyles = (input: PreparedInput, brand: BrandResult) => {
 const buildConfig = (
   input: PreparedInput,
   analysis: ContentAnalysis,
-  brand: BrandResult,
-  theme?: 'secondary'
+  brand: BrandResult
 ): WidgetConfig => {
   const logoUrl = input.logoUrl || brand.logoUrl
   const config: WidgetConfig = {
@@ -43,7 +42,9 @@ const buildConfig = (
     config.logoUrl = ''
   }
 
-  if (theme) config.theme = theme
+  // 'primary' is the widget's own default theme — only set it explicitly for
+  // 'secondary', same as the config always did.
+  if (brand.theme === 'secondary') config.theme = 'secondary'
   return config
 }
 
@@ -85,14 +86,12 @@ ${escapeForInlineScript(JSON.stringify(config, undefined, 2))}
 </body>
 </html>`
 
-/* Builds the primary and secondary widget landing pages. Unlike the n8n "Build
- * HTML" node (which string-templated raw JSON and was fragile), this builds a
- * real config object and serializes it, so escaping is always correct. */
+/* Builds the widget landing page in whichever theme detectBrand picked for
+ * this logo/color combination. Unlike the n8n "Build HTML" node (which
+ * string-templated raw JSON and was fragile), this builds a real config
+ * object and serializes it, so escaping is always correct. */
 export const buildHtml = (
   input: PreparedInput,
   analysis: ContentAnalysis,
   brand: BrandResult
-): { primary: string; secondary: string } => ({
-  primary: renderHtml(buildConfig(input, analysis, brand)),
-  secondary: renderHtml(buildConfig(input, analysis, brand, 'secondary'))
-})
+): string => renderHtml(buildConfig(input, analysis, brand))

--- a/apps/demo-setup/src/pipeline/detect-brand.ts
+++ b/apps/demo-setup/src/pipeline/detect-brand.ts
@@ -1,71 +1,357 @@
 import { anthropic } from '@ai-sdk/anthropic'
 import { generateObject, jsonSchema } from 'ai'
+import { contrastFromLuminances, luminance, parseRgb } from '../lib/color'
 import { env } from '../config/env'
+import { logger } from '../lib/logger'
+import { estimateLogoInkLuminance, sampleLogoColor } from './sample-logo-color'
 import type { BrandCandidates } from './extract-brand-candidates'
-import type { BrandResult, PreparedInput } from '../types'
+import type { BrandProbe, BrandResult, PixelRect, PreparedInput } from '../types'
 
-/* JSON schema (not zod) to stay decoupled from the workspace's mixed zod
- * versions, which conflict with the AI SDK types. */
-const brandSchema = jsonSchema<BrandResult>({
+/* The model picks *indices* for colors, never invents a hex — "#7A2C3D" for a
+ * site whose actual brand is "#7B2D3E" looks right in a chat reply and wrong
+ * next to the real site. Every color it can return is a string we read out of
+ * the live DOM or the rendered pixels.
+ *
+ * The logo is different: asking for an index into a text-described list is
+ * exactly how the real horse-emblem logo on West Hills Vineyards got missed —
+ * it wasn't a top candidate by any selector heuristic, so it was never index 0
+ * or 1 in a list a model skims. A human designer just points at the picture.
+ * So logoBox asks the model to do the same: locate the logo visually, as a
+ * bounding box on the screenshot. We then match that box against whatever
+ * concrete asset (image URL or inline SVG) sits in the same place — turning
+ * vision into a spatial filter over real candidates, not a freeform picker. */
+type BrandSelection = {
+  primaryIndex: number
+  logoBox: {
+    found: boolean
+    xPct: number
+    yPct: number
+    widthPct: number
+    heightPct: number
+  }
+}
+
+const selectionSchema = jsonSchema<BrandSelection>({
   type: 'object',
   additionalProperties: false,
-  required: ['logoUrl', 'brandColor', 'fontFamily'],
+  required: ['primaryIndex', 'logoBox'],
   properties: {
-    logoUrl: {
-      type: 'string',
+    primaryIndex: {
+      type: 'integer',
       description:
-        "The URL most likely to be the site's official brand logo (prefer SVG/PNG/JPG named logo/brand over favicons). Empty string if none suitable."
+        "Index of the color that visually dominates this brand's identity — the color used most prominently across the header, navigation, buttons, and accents in the screenshot. Think like a designer describing the brand's \"main color\": not necessarily the single largest area (a photo background doesn't count), but the flat brand color that recurs across UI elements. Never a white, off-white, black, or grey page background. When several candidates are near-identical shades of the same hue, prefer whichever one's note says it covers more of the rendered page — that measurement comes directly from the screenshot's pixels and can't be wrong the way a CSS variable name can (site builders like Wix often name variables generically, e.g. '--wst-color-custom-4', which tells you nothing about whether it's actually the primary color). Use -1 if none of the candidates match."
     },
-    brandColor: {
-      type: 'string',
+    logoBox: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['found', 'xPct', 'yPct', 'widthPct', 'heightPct'],
       description:
-        'The primary brand color (bold, saturated, used for buttons/links/accents), not white/black/neutral backgrounds. Empty string if none found.'
-    },
-    fontFamily: {
-      type: 'string',
-      description:
-        "The website's primary body font family (or full font stack). Empty string if none found."
+        "Locate the company's logo mark or wordmark as it visually appears in the screenshot — this may be a text wordmark in the header, OR a distinct pictorial mark/emblem/seal (e.g. an icon, crest, or illustration representing the brand), which is often the more recognizable 'logo' even if a text banner also appears elsewhere on the page. Prefer the pictorial mark over a plain text banner when both are present.",
+      properties: {
+        found: {
+          type: 'boolean',
+          description: 'true if a distinct logo mark or wordmark is visible anywhere in the screenshot'
+        },
+        xPct: { type: 'number', description: 'Left edge of the logo, as a percentage (0-100) of the screenshot width' },
+        yPct: { type: 'number', description: 'Top edge of the logo, as a percentage (0-100) of the screenshot height' },
+        widthPct: { type: 'number', description: 'Width of the logo, as a percentage (0-100) of the screenshot width' },
+        heightPct: { type: 'number', description: 'Height of the logo, as a percentage (0-100) of the screenshot height' }
+      }
     }
   }
 })
 
-/* Single LLM call that replaces the old three "Determination" nodes (logo,
- * color, font). Only invoked for signals the caller did not already supply.
- * Returns the caller-supplied values verbatim for any field already set. */
+/* Sample color directly from the logo image's own pixels, weighted by
+ * saturation — the technique the open-source OpenBrand project uses. A logo
+ * is (almost) never a photo, so this sidesteps the whole-page pixel scan's
+ * failure mode entirely (a gradient hero sky can never masquerade as "flat").
+ * Favicon/apple-touch-icon go first: a favicon is commonly simplified to a
+ * single dominant brand chip precisely because it renders at 16-32px, which
+ * often makes it a *more* reliable color source than the full logo mark.
+ * Bounded to a handful of candidates so one slow/dead image can't stall brand
+ * detection; a monochrome logo (WHV's cream line-art horse emblem, say)
+ * legitimately yields nothing here; other tiers cover that case. */
+const sampleLogoColors = async (probe: BrandProbe): Promise<string[]> => {
+  const logos = probe.logos ?? []
+  const byKind = (kind: string) => logos.filter(logo => logo.kind === kind)
+  const candidates = [
+    ...byKind('apple-touch-icon'),
+    ...byKind('favicon'),
+    ...[...logos]
+      .filter(logo => !['apple-touch-icon', 'favicon', 'ld+json', 'og'].includes(logo.kind))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 2)
+  ].slice(0, 4)
+
+  const results = await Promise.all(candidates.map(logo => sampleLogoColor(logo.url)))
+  return [...new Set(results.filter((hex): hex is string => hex !== null))]
+}
+
+type ColorCandidate = { hex: string; note: string }
+
+/* Rank the probe's color signals into one candidate list, each carrying a
+ * human-readable note so the vision prompt can explain *why* a candidate is
+ * there — critical when two near-identical greens both show up (a real
+ * dominant color and a minor accent) and the model has to pick between them.
+ *
+ * Screenshot pixel-dominance leads: it's measured directly off the rendered
+ * page and ranked by how much of it a color actually covers, so it can't lie
+ * the way a CSS variable name can (West Hills Vineyards' Wix theme names its
+ * real primary "--wst-color-custom-4" — a generic index that gives no signal
+ * it's the important one). Logo-sampled colors come next: exact pixel data
+ * from a small, almost-certainly-not-a-photo image, though note this can
+ * legitimately point at a *different* image than the one that ends up as
+ * logoUrl (that's matched separately, by vision-bbox position). CSS custom
+ * properties named primary/brand and per-element computed styles fill out
+ * the rest. */
+const rankColors = (probe: BrandProbe, logoColors: string[]): ColorCandidate[] => {
+  const ranked: ColorCandidate[] = []
+  const seen = new Set<string>()
+  const push = (hex: string | null | undefined, note: string) => {
+    if (!hex) return
+    const normalized = hex.toLowerCase()
+    if (seen.has(normalized)) return
+    seen.add(normalized)
+    ranked.push({ hex: normalized, note })
+  }
+
+  for (const color of probe.pixelDominantColors ?? []) {
+    push(color.hex, `covers ${Math.round(color.coverage * 100)}% of the rendered page (dominant flat color)`)
+  }
+  for (const hex of logoColors) push(hex, 'sampled from the logo/icon image pixels')
+  for (const variable of probe.cssVariables ?? []) {
+    push(
+      variable.hex,
+      variable.weight >= 60
+        ? `CSS variable named "${variable.name}" (explicitly named primary/brand/accent)`
+        : `CSS variable "${variable.name}" (generic name, no signal on purpose)`
+    )
+  }
+  for (const color of probe.computedColors ?? []) {
+    push(color.hex, `computed style, used ${color.uses}x on ${color.sources.join(', ')}`)
+  }
+  push(probe.themeColor, 'meta theme-color')
+
+  return ranked.slice(0, 10)
+}
+
+/* A data: URI is a legitimate logo (we serialize inline <svg> wordmarks), but it
+ * can be 20KB — far too long to put in a prompt. Show the model a stable stub
+ * and map the index back to the real value afterwards. */
+const describeLogo = (url: string): string =>
+  url.startsWith('data:')
+    ? `${url.slice(0, 40)}… (inline SVG, ${url.length} chars)`
+    : url
+
+const pick = (list: ColorCandidate[], index: number): string =>
+  Number.isInteger(index) && index >= 0 && index < list.length ? list[index].hex : ''
+
+const intersectionOverUnion = (a: PixelRect, b: PixelRect): number => {
+  const x1 = Math.max(a.left, b.left)
+  const y1 = Math.max(a.top, b.top)
+  const x2 = Math.min(a.left + a.width, b.left + b.width)
+  const y2 = Math.min(a.top + a.height, b.top + b.height)
+  const overlap = Math.max(0, x2 - x1) * Math.max(0, y2 - y1)
+  if (overlap <= 0) return 0
+  const union = a.width * a.height + b.width * b.height - overlap
+  return union > 0 ? overlap / union : 0
+}
+
+/* The model localizes the logo visually; this resolves that location to a
+ * concrete asset by finding whichever candidate's on-page position overlaps
+ * it best. Lenient IoU threshold — the model's box is a rough visual estimate,
+ * not a precise crop, so demanding tight overlap would reject good matches. */
+const matchLogoByPosition = (
+  logos: NonNullable<BrandProbe['logos']>,
+  box: BrandSelection['logoBox'],
+  screenshotWidth: number,
+  screenshotHeight: number
+): string => {
+  if (!box.found || !screenshotWidth || !screenshotHeight) return ''
+  const target: PixelRect = {
+    left: (box.xPct / 100) * screenshotWidth,
+    top: (box.yPct / 100) * screenshotHeight,
+    width: (box.widthPct / 100) * screenshotWidth,
+    height: (box.heightPct / 100) * screenshotHeight
+  }
+
+  let best: { url: string; iou: number } | null = null
+  for (const logo of logos) {
+    if (!logo.rect) continue
+    const iou = intersectionOverUnion(target, logo.rect)
+    if (iou > 0.05 && (!best || iou > best.iou)) best = { url: logo.url, iou }
+  }
+  return best?.url ?? ''
+}
+
+/* Picks which widget header style the logo actually looks good on. Compares
+ * the logo's own ink luminance against a colored header (brandColor) and a
+ * white header, and keeps whichever gives better contrast — a logo drawn as
+ * white-only art (Pizzeria Bianco's `bianco-logo-white.png`, made for a dark
+ * photo backdrop) would go invisible on a white 'secondary' header, and the
+ * reverse is just as real for a dark wordmark against a colored one. Defaults
+ * to 'primary' (the more brand-forward option) when there's no logo, or no
+ * ink-luminance signal to compare with (fetch failure, unrasterizable SVG). */
+const WHITE_LUMINANCE = 1
+const pickTheme = async (
+  logoUrl: string,
+  brandColor: string,
+  companyId: string
+): Promise<'primary' | 'secondary'> => {
+  if (!logoUrl) return 'primary'
+  const inkLuminance = await estimateLogoInkLuminance(logoUrl)
+  const brandRgb = parseRgb(brandColor)
+  if (inkLuminance === null || !brandRgb) return 'primary'
+
+  const contrastOnPrimary = contrastFromLuminances(inkLuminance, luminance(brandRgb))
+  const contrastOnWhite = contrastFromLuminances(inkLuminance, WHITE_LUMINANCE)
+  const theme = contrastOnPrimary >= contrastOnWhite ? 'primary' : 'secondary'
+  logger.info(
+    `[brand ${companyId}] theme=${theme} (logo contrast: ${contrastOnPrimary.toFixed(1)} on primary vs ${contrastOnWhite.toFixed(1)} on white)`
+  )
+  return theme
+}
+
+/* Selects the site's real brand signals. The probe gives us exact values from
+ * the live DOM and rendered pixels; the vision call decides which of them the
+ * brand actually leads with (colors) and where the logo visually sits (matched
+ * back to a real asset by position). Falls back to the probe's own ranking
+ * whenever the model abstains, and to the legacy HTML-regex candidates when
+ * the probe couldn't run at all.
+ *
+ * Caller-supplied values always win and skip the LLM. */
 export const detectBrand = async (
   input: PreparedInput,
-  candidates: BrandCandidates
+  probe: BrandProbe,
+  screenshot: string,
+  screenshotWidth: number,
+  screenshotHeight: number,
+  fallback: BrandCandidates
 ): Promise<BrandResult> => {
   const supplied = {
     logoUrl: input.logoUrl,
     brandColor: input.styles?.primaryColor,
+    secondaryColor: input.styles?.secondaryColor,
     fontFamily: input.styles?.fontFamily
   }
 
-  // Nothing to infer — skip the LLM entirely.
-  if (supplied.logoUrl && supplied.brandColor && supplied.fontFamily) {
+  const font =
+    supplied.fontFamily ||
+    probe.fonts?.body ||
+    fallback.fontCandidates[0] ||
+    ''
+
+  if (supplied.logoUrl && supplied.brandColor) {
     return {
       logoUrl: supplied.logoUrl,
       brandColor: supplied.brandColor,
-      fontFamily: supplied.fontFamily
+      secondaryColor: supplied.secondaryColor ?? '',
+      fontFamily: font,
+      theme: await pickTheme(supplied.logoUrl, supplied.brandColor, input.companyId)
     }
   }
 
-  const { object } = await generateObject({
-    model: anthropic(env.modelBrand),
-    schema: brandSchema,
-    system:
-      'You are a web branding analyst. Given candidate logo URLs, colors, and font families extracted from a website, select the single best value for each, following the field descriptions.',
-    prompt: [
-      `Logo candidates:\n${candidates.logoCandidates.join('\n') || '(none)'}`,
-      `Color candidates:\n${candidates.colorCandidates.join('\n') || '(none)'}`,
-      `Font candidates:\n${candidates.fontCandidates.join('\n') || '(none)'}`
-    ].join('\n\n')
-  })
+  const logoColors = await sampleLogoColors(probe)
+  const colorPool = rankColors(probe, logoColors)
+  const finalColorPool = colorPool.length
+    ? colorPool
+    : fallback.colorCandidates.map(hex => ({ hex, note: 'legacy HTML-regex candidate' }))
+  const logos = probe.logos ?? []
+  // Ranked purely for the text list shown to the model / the no-vision fallback
+  // path; the logo that actually gets used comes from position matching below.
+  const logoPool = [...logos].sort((a, b) => b.score - a.score).map(logo => logo.url)
+  const finalLogoPool = logoPool.length ? logoPool : fallback.logoCandidates
 
+  // Secondary color is deliberately not detected: it only paints the assistant
+  // chat bubble background, isn't a prominent brand signal on most sites, and
+  // guessing wrong (a saturated color behind fixed dark text) reads worse than
+  // just using the widget's own neutral default. Caller-supplied override
+  // still wins; quality.ts's contrast guard still applies to it.
+  const secondaryColor = supplied.secondaryColor ?? ''
+
+  // Nothing to choose between, or no screenshot to choose with — take the top
+  // ranked candidate rather than burning a vision call to confirm the obvious.
+  if (!screenshot || (finalColorPool.length <= 1 && finalLogoPool.length <= 1)) {
+    if (!screenshot) {
+      logger.warn(
+        `[brand ${input.companyId}] no screenshot; using probe ranking directly`
+      )
+    }
+    const logoUrl = supplied.logoUrl ?? finalLogoPool[0] ?? ''
+    const brandColor = supplied.brandColor ?? finalColorPool[0]?.hex ?? ''
+    return {
+      logoUrl,
+      brandColor,
+      secondaryColor,
+      fontFamily: font,
+      theme: await pickTheme(logoUrl, brandColor, input.companyId)
+    }
+  }
+
+  const prompt = [
+    `Website: ${input.companyWebsite}`,
+    '',
+    'Colors sampled from the live page (index: value — note):',
+    ...finalColorPool.map((candidate, index) => `${index}: ${candidate.hex} — ${candidate.note}`),
+    '',
+    'For reference, images found on the page that might be the logo (not used by index — locate the logo visually in the screenshot instead):',
+    ...finalLogoPool.map((url, index) => `${index}: ${describeLogo(url)}`),
+    '',
+    'The attached screenshot is the top of this homepage.'
+  ].join('\n')
+
+  let selection: BrandSelection
+  try {
+    const { object } = await generateObject({
+      model: anthropic(env.modelBrand),
+      schema: selectionSchema,
+      system:
+        "You are a brand designer reviewing a website screenshot. Identify the brand's primary color from the given candidate list by index, and locate the company's logo visually in the image (as a bounding box), the way a designer would point at it — not by guessing which listed URL it corresponds to.",
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: prompt },
+            { type: 'image', image: screenshot, mediaType: 'image/jpeg' }
+          ]
+        }
+      ]
+    })
+    selection = object
+  } catch (error) {
+    logger.warn(
+      `[brand ${input.companyId}] vision selection failed (${error}); using probe ranking`
+    )
+    selection = {
+      primaryIndex: 0,
+      logoBox: { found: false, xPct: 0, yPct: 0, widthPct: 0, heightPct: 0 }
+    }
+  }
+
+  // -1 means "none of these" — fall back to the probe's own top pick rather than
+  // shipping an empty color, which quality.ts would replace with a generic blue.
+  const primary = pick(finalColorPool, selection.primaryIndex) || finalColorPool[0]?.hex || ''
+
+  const positionMatchedLogo = matchLogoByPosition(
+    logos,
+    selection.logoBox,
+    screenshotWidth,
+    screenshotHeight
+  )
+  const logoUrl = supplied.logoUrl ?? positionMatchedLogo ?? finalLogoPool[0] ?? ''
+
+  logger.info(
+    `[brand ${input.companyId}] primary=${primary} ` +
+      `logo=${positionMatchedLogo ? 'position-matched' : logoUrl ? 'top-ranked fallback' : 'none'} ` +
+      `from ${finalColorPool.length} colors, ${finalLogoPool.length} logo candidates`
+  )
+
+  const brandColor = supplied.brandColor ?? primary
   return {
-    logoUrl: supplied.logoUrl ?? object.logoUrl,
-    brandColor: supplied.brandColor ?? object.brandColor,
-    fontFamily: supplied.fontFamily ?? object.fontFamily
+    logoUrl,
+    brandColor,
+    secondaryColor,
+    fontFamily: font,
+    theme: await pickTheme(logoUrl, brandColor, input.companyId)
   }
 }

--- a/apps/demo-setup/src/pipeline/quality.ts
+++ b/apps/demo-setup/src/pipeline/quality.ts
@@ -1,5 +1,6 @@
+import { contrastRatio, parseRgb, toHex, type Rgb } from '../lib/color'
 import { logger } from '../lib/logger'
-import type { BrandResult, ContentAnalysis } from '../types'
+import type { BrandResult, ContentAnalysis, Suggestion } from '../types'
 
 const isValidHttpUrl = (value: string): boolean => {
   try {
@@ -16,6 +17,60 @@ const isValidCssColor = (value: string): boolean =>
 const DEFAULT_BRAND_COLOR = '#1d4ed8'
 const DEFAULT_FONT_FAMILY = 'system-ui, sans-serif'
 
+/* The widget paints white text on primaryColor (--df-color-primary). WCAG AA for
+ * large text / UI components is 3:1; below that the send button is unreadable. */
+const MIN_CONTRAST_ON_WHITE = 3
+const WHITE: Rgb = { r: 255, g: 255, b: 255 }
+
+/* Scale the color toward black. Multiplying all three channels by the same
+ * factor keeps the hue and saturation intact, so a pale brand yellow darkens to
+ * a readable amber rather than being thrown away for a generic blue. */
+const darkenToContrast = (color: Rgb): Rgb => {
+  let current = color
+  for (let i = 0; i < 20 && contrastRatio(current, WHITE) < MIN_CONTRAST_ON_WHITE; i++) {
+    current = { r: current.r * 0.9, g: current.g * 0.9, b: current.b * 0.9 }
+  }
+  return current
+}
+
+/* secondaryColor paints the assistant message bubble (message.tsx: `bg-secondary
+ * df:text-foreground`), and the widget always renders it with the fixed dark
+ * foreground text below — never white — so it must be checked against that
+ * exact color, not against white. Matches ConfigContext's default
+ * `foregroundColor: '#1f2937'`. */
+const FOREGROUND_TEXT_COLOR: Rgb = { r: 0x1f, g: 0x29, b: 0x37 }
+const MIN_CONTRAST_SECONDARY_TEXT = 4.5
+
+/* Scale the color toward white rather than black — the bubble needs to stay
+ * light enough to carry the fixed dark text, so darkening (as primaryColor
+ * gets) would make this worse, not better. */
+const lightenToContrast = (color: Rgb, against: Rgb): Rgb => {
+  let current = color
+  for (let i = 0; i < 20 && contrastRatio(current, against) < MIN_CONTRAST_SECONDARY_TEXT; i++) {
+    current = {
+      r: current.r + (255 - current.r) * 0.15,
+      g: current.g + (255 - current.g) * 0.15,
+      b: current.b + (255 - current.b) * 0.15
+    }
+  }
+  return current
+}
+
+/* Derive a button label from a question when the model omits one. */
+const labelFromPrompt = (prompt: string): string =>
+  prompt
+    .replace(/[?.!,]/g, '')
+    .split(/\s+/)
+    .filter(word => !/^(do|does|can|what|how|is|are|the|a|an|you|your|i|we)$/i.test(word))
+    .slice(0, 3)
+    .join(' ')
+    .replace(/\b\w/g, character => character.toUpperCase()) || 'Learn More'
+
+const FALLBACK_SUGGESTION: Suggestion = {
+  label: 'What You Offer',
+  prompt: 'What do you offer?'
+}
+
 /* Validates the generated analysis + brand fields before publish, and repairs
  * anything that fails so a bad LLM output never ships a broken widget (empty
  * welcome message, malformed color, garbage logo URL). Logs every repair so
@@ -30,17 +85,21 @@ export const enforceQuality = (
 
   if (!safeAnalysis.welcomeMessage?.trim()) {
     logger.warn(`[quality ${companyId}] empty welcomeMessage, using fallback`)
-    safeAnalysis.welcomeMessage = `Welcome! Have a question? Just type it here and I'll help out.`
+    safeAnalysis.welcomeMessage = `**Welcome!**\n\nHave a question? Just type it here and I'll help out.`
   }
 
-  if (safeAnalysis.suggestions?.length !== 4) {
+  const suggestions = (safeAnalysis.suggestions ?? []).map(suggestion => ({
+    label: suggestion.label?.trim() || labelFromPrompt(suggestion.prompt ?? ''),
+    prompt: suggestion.prompt?.trim() ?? ''
+  }))
+  const usable = suggestions.filter(suggestion => suggestion.prompt)
+  if (usable.length !== 4) {
     logger.warn(
-      `[quality ${companyId}] expected 4 suggestions, got ${safeAnalysis.suggestions?.length ?? 0}`
+      `[quality ${companyId}] expected 4 suggestions, got ${usable.length}`
     )
-    const prompts = safeAnalysis.suggestions?.map(s => s.prompt) ?? []
-    while (prompts.length < 4) prompts.push('What do you offer?')
-    safeAnalysis.suggestions = prompts.slice(0, 4).map(p => ({ prompt: p }))
+    while (usable.length < 4) usable.push(FALLBACK_SUGGESTION)
   }
+  safeAnalysis.suggestions = usable.slice(0, 4)
 
   if (safeBrand.brandColor && !isValidCssColor(safeBrand.brandColor)) {
     logger.warn(
@@ -51,13 +110,47 @@ export const enforceQuality = (
     safeBrand.brandColor = DEFAULT_BRAND_COLOR
   }
 
+  // The site's real color may be too light to carry white widget text. Darken it
+  // rather than discard it — a dark version of their brand still reads as theirs.
+  const primary = parseRgb(safeBrand.brandColor)
+  if (primary && contrastRatio(primary, WHITE) < MIN_CONTRAST_ON_WHITE) {
+    const darkened = toHex(darkenToContrast(primary))
+    logger.warn(
+      `[quality ${companyId}] brandColor ${safeBrand.brandColor} fails contrast on white; darkened to ${darkened}`
+    )
+    safeBrand.brandColor = darkened
+  }
+
+  if (safeBrand.secondaryColor && !isValidCssColor(safeBrand.secondaryColor)) {
+    logger.warn(
+      `[quality ${companyId}] invalid secondaryColor "${safeBrand.secondaryColor}", dropping`
+    )
+    safeBrand.secondaryColor = ''
+  }
+
+  // The assistant bubble always renders this color behind fixed dark text
+  // (never white) — a dark or highly saturated secondaryColor makes that text
+  // unreadable. Lighten toward white rather than dropping it, same rationale
+  // as brandColor's darken-not-discard treatment above.
+  const secondary = safeBrand.secondaryColor ? parseRgb(safeBrand.secondaryColor) : null
+  if (secondary && contrastRatio(secondary, FOREGROUND_TEXT_COLOR) < MIN_CONTRAST_SECONDARY_TEXT) {
+    const lightened = toHex(lightenToContrast(secondary, FOREGROUND_TEXT_COLOR))
+    logger.warn(
+      `[quality ${companyId}] secondaryColor ${safeBrand.secondaryColor} fails contrast against bubble text; lightened to ${lightened}`
+    )
+    safeBrand.secondaryColor = lightened
+  }
+
   if (!safeBrand.fontFamily) {
     safeBrand.fontFamily = DEFAULT_FONT_FAMILY
   }
 
-  if (safeBrand.logoUrl && !isValidHttpUrl(safeBrand.logoUrl)) {
+  // Inline-SVG logos are serialized to data: URIs by the brand probe, which
+  // isValidHttpUrl would reject — the widget renders them in an <img> just fine.
+  const isDataImage = safeBrand.logoUrl?.startsWith('data:image/')
+  if (safeBrand.logoUrl && !isDataImage && !isValidHttpUrl(safeBrand.logoUrl)) {
     logger.warn(
-      `[quality ${companyId}] invalid logoUrl "${safeBrand.logoUrl}", dropping`
+      `[quality ${companyId}] invalid logoUrl "${safeBrand.logoUrl.slice(0, 80)}", dropping`
     )
     safeBrand.logoUrl = ''
   }

--- a/apps/demo-setup/src/pipeline/run-pipeline.ts
+++ b/apps/demo-setup/src/pipeline/run-pipeline.ts
@@ -40,11 +40,13 @@ export const runPipeline = async (
   env.upstash()
   env.crawlerOpenaiApiKey()
 
-  // Single real-browser scrape (crawl4ai) provides both the page content for
-  // analysis and the rendered homepage HTML for brand-candidate extraction.
+  // Single real-browser scrape (crawl4ai) provides page content for analysis,
+  // computed-style brand signals (colors/logo/fonts read live off the DOM), and
+  // a screenshot for the vision-based brand tiebreak. The HTML-regex candidates
+  // are now only a fallback for when the in-browser probe couldn't run.
   const scraped = await scrapeForDemo(input.companyWebsite)
   const pages = scraped.pages.map(page => page.markdown)
-  const candidates = extractBrandCandidates(
+  const fallbackCandidates = extractBrandCandidates(
     scraped.homepageHtml,
     input.companyWebsite
   )
@@ -52,7 +54,14 @@ export const runPipeline = async (
   // The two consolidated LLM calls, run in parallel.
   const [rawAnalysis, rawBrand] = await Promise.all([
     analyzeContent(pages),
-    detectBrand(input, candidates)
+    detectBrand(
+      input,
+      scraped.brand,
+      scraped.screenshot,
+      scraped.screenshotWidth,
+      scraped.screenshotHeight,
+      fallbackCandidates
+    )
   ])
 
   const { analysis, brand } = enforceQuality(
@@ -63,7 +72,7 @@ export const runPipeline = async (
 
   const systemPrompt = buildSystemPrompt(input, analysis)
 
-  // Persist config and upload the demo pages in parallel.
+  // Persist config and upload the demo page in parallel.
   const html = buildHtml(input, analysis, brand)
   const [, demoUrl] = await Promise.all([
     persistCompanyConfig(input, systemPrompt),

--- a/apps/demo-setup/src/pipeline/sample-logo-color.ts
+++ b/apps/demo-setup/src/pipeline/sample-logo-color.ts
@@ -1,0 +1,109 @@
+import sharp from 'sharp'
+import { Vibrant } from 'node-vibrant/node'
+import { luminance } from '../lib/color'
+
+/* Mirrors the technique used by the open-source OpenBrand project
+ * (github.com/ethanjyx/OpenBrand): a logo is (almost) never a photo, so
+ * sampling its own pixels is a far more reliable brand-color signal than
+ * scanning the whole page — no gradients, no hero photos to filter out.
+ *
+ * The actual quantization/scoring is node-vibrant (the same median-cut +
+ * population/saturation scoring algorithm as Android's Palette API,
+ * battle-tested across millions of apps) rather than a hand-rolled
+ * saturation-weighted histogram — that homegrown version was fooled by
+ * stray high-saturation garbage pixels sharp's `.removeAlpha()` exposed
+ * under fully-transparent regions of a WixStatic-served PNG (see the
+ * flatten-onto-white step below, which fixes that at the source).
+ *
+ * Returns null for a genuinely monochrome logo (a white/black line-art
+ * mark, say) — that's a legitimate "no signal here", not a failure; the
+ * caller has other tiers. */
+
+const SAMPLE_SIZE = 128
+const FETCH_TIMEOUT_MS = 5000
+
+const toBuffer = async (url: string): Promise<Buffer | null> => {
+  if (url.startsWith('data:')) {
+    const base64 = url.split(',')[1]
+    return base64 ? Buffer.from(base64, 'base64') : null
+  }
+  try {
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
+    })
+    if (!response.ok) return null
+    return Buffer.from(await response.arrayBuffer())
+  } catch {
+    return null
+  }
+}
+
+export const sampleLogoColor = async (url: string): Promise<string | null> => {
+  const buffer = await toBuffer(url)
+  if (!buffer) return null
+
+  try {
+    // Flatten transparency onto white before handing off to Vibrant — a
+    // logo mark is drawn assuming a light background, and compositing onto
+    // real white (rather than leaving raw, possibly-garbage RGB under
+    // transparent pixels) is what makes the sampled color trustworthy.
+    const flattened = await sharp(buffer)
+      .resize(SAMPLE_SIZE, SAMPLE_SIZE, { fit: 'inside', withoutEnlargement: true })
+      .flatten({ background: { r: 255, g: 255, b: 255 } })
+      .png()
+      .toBuffer()
+
+    const palette = await Vibrant.from(flattened).getPalette()
+    // Prefer a genuinely vibrant swatch over a muted one — a brand mark's
+    // "brand color" is its most saturated ink, not its most populous pixel
+    // (which on a mostly-white logo would just be white/near-white, already
+    // filtered out by Vibrant's own saturation/population scoring).
+    const swatch =
+      palette.Vibrant ??
+      palette.DarkVibrant ??
+      palette.LightVibrant ??
+      palette.Muted ??
+      palette.DarkMuted ??
+      palette.LightMuted ??
+      null
+    return swatch?.hex ?? null
+  } catch {
+    // Corrupt image, unsupported format, oversized SVG — not worth failing
+    // brand detection over one bad candidate.
+    return null
+  }
+}
+
+/* Average luminance of the logo's own drawn pixels — deliberately *not*
+ * flattened onto a background first, unlike sampleLogoColor above. Flattening
+ * would bias this toward whatever fill color we picked (white) rather than
+ * telling us anything about the mark itself, which is exactly what picking a
+ * widget header theme needs: "is this logo light or dark ink, regardless of
+ * what it's normally shown against?" Used to decide whether a colored
+ * (primaryColor) or white header background gives the logo better contrast. */
+export const estimateLogoInkLuminance = async (url: string): Promise<number | null> => {
+  const buffer = await toBuffer(url)
+  if (!buffer) return null
+
+  try {
+    const { data, info } = await sharp(buffer)
+      .resize(SAMPLE_SIZE, SAMPLE_SIZE, { fit: 'inside', withoutEnlargement: true })
+      .ensureAlpha()
+      .raw()
+      .toBuffer({ resolveWithObject: true })
+
+    let total = 0
+    let count = 0
+    const OPAQUE_THRESHOLD = 200
+    for (let i = 0; i < data.length; i += info.channels) {
+      const alpha = data[i + 3]
+      if (alpha < OPAQUE_THRESHOLD) continue
+      total += luminance({ r: data[i], g: data[i + 1], b: data[i + 2] })
+      count += 1
+    }
+    if (!count) return null
+    return total / count
+  } catch {
+    return null
+  }
+}

--- a/apps/demo-setup/src/queue/worker.ts
+++ b/apps/demo-setup/src/queue/worker.ts
@@ -3,7 +3,7 @@ import { env } from '../config/env'
 import { logger } from '../lib/logger'
 import { deriveCompanyId } from '../lib/slug'
 import { killActiveCrawls } from '../integrations/crawler'
-import { sendDemoReadyEmail, sendInternalAlert } from '../integrations/sendgrid'
+import { sendDemoPendingEmail, sendDemoReadyEmail, sendInternalAlert } from '../integrations/sendgrid'
 import { runPipeline } from '../pipeline/run-pipeline'
 import {
   claimPending,
@@ -37,6 +37,15 @@ const processRequest = async (row: DemoRequestRow): Promise<void> => {
   const companyId = row.company_id ?? deriveCompanyId(row.company_name)
   if (!row.company_id) await setCompanyId(row.id, companyId)
 
+  // Best-effort: a prospect not getting this receipt is far less costly than
+  // stalling the actual build over a SendGrid hiccup, so don't await-and-fail
+  // the request over it.
+  void sendDemoPendingEmail({
+    to: row.delivery_email,
+    companyId,
+    companyName: row.company_name
+  })
+
   const { demoUrl, crawlDone } = await runPipeline({
     companyId,
     companyName: row.company_name,
@@ -51,7 +60,7 @@ const processRequest = async (row: DemoRequestRow): Promise<void> => {
   // that can't answer anything about them.
   await crawlDone
 
-  const sent = await sendDemoReadyEmail({ to: row.delivery_email, companyId })
+  const sent = await sendDemoReadyEmail({ to: row.delivery_email, companyId, demoUrl })
   await markComplete(row.id)
 
   if (!sent) {
@@ -163,12 +172,16 @@ export const startWorker = (): void => {
   }
 
   // The reaper must not be able to steal a row from a worker that is merely
-  // slow. Worst case a job takes scrape + crawl plus the LLM calls between them.
-  const worstCaseMs = env.scrapeTimeoutMs + env.crawlTimeoutMs
+  // slow. Worst case a job takes scrape + crawl plus the LLM calls between them
+  // (analyze-content, detect-brand) — those aren't individually bounded by a
+  // timeout, so budget a fixed allowance for them rather than ignoring them.
+  const LLM_CALL_BUDGET_MS = 5 * 60 * 1000
+  const worstCaseMs = env.scrapeTimeoutMs + env.crawlTimeoutMs + LLM_CALL_BUDGET_MS
   if (env.queueStaleMinutes * 60_000 <= worstCaseMs) {
     throw new Error(
-      `DEMO_STALE_MINUTES (${env.queueStaleMinutes}m) must exceed SCRAPE_TIMEOUT_MS + CRAWL_TIMEOUT_MS ` +
-        `(${Math.ceil(worstCaseMs / 60_000)}m), or the reaper will reclaim rows a healthy worker still holds.`
+      `DEMO_STALE_MINUTES (${env.queueStaleMinutes}m) must exceed SCRAPE_TIMEOUT_MS + CRAWL_TIMEOUT_MS + ` +
+        `${LLM_CALL_BUDGET_MS / 60_000}m LLM budget (${Math.ceil(worstCaseMs / 60_000)}m), or the reaper ` +
+        `will reclaim rows a healthy worker still holds.`
     )
   }
 

--- a/apps/demo-setup/src/types.ts
+++ b/apps/demo-setup/src/types.ts
@@ -41,7 +41,10 @@ export type PreparedInput = Omit<DemoInput, 'isProd'> & {
   namespace: string
 }
 
-export type Suggestion = { prompt: string }
+/* `label` is the button text the widget renders; `prompt` is what it sends when
+ * clicked (see ChatInterface's `suggestion.label || suggestion.prompt`). The
+ * button is ~140px wide, so a full question only reads well as a short label. */
+export type Suggestion = { label: string; prompt: string }
 
 /* Output of the single content-analysis LLM call. */
 export type ContentAnalysis = {
@@ -54,11 +57,46 @@ export type ContentAnalysis = {
   suggestions: Suggestion[]
 }
 
-/* Output of the single brand-detection LLM call. */
+/* Output of the single brand-detection LLM call. `theme` picks which widget
+ * header style the demo ships with — 'primary' paints the header in
+ * brandColor (the logo sits on top of it), 'secondary' keeps it white (the
+ * logo sits on a neutral background, brandColor shows up as accents/border
+ * instead). Chosen by comparing the logo's own ink luminance against each
+ * option, so a light-only logo (e.g. a mark drawn for a white background)
+ * doesn't get rendered on top of a background that swallows it. */
 export type BrandResult = {
   logoUrl: string
   brandColor: string
+  secondaryColor: string
   fontFamily: string
+  theme: 'primary' | 'secondary'
+}
+
+export type PixelRect = { top: number; left: number; width: number; height: number }
+
+/* Brand signals read out of the live DOM by web-crawler/brand_probe.js. Every
+ * field is best-effort: a page that blocks script evaluation yields {}. */
+export type BrandProbe = {
+  cssVariables?: { name: string; hex: string; weight: number }[]
+  computedColors?: { hex: string; score: number; uses: number; sources: string[] }[]
+  // Which flat (non-photographic) color covers the most of the rendered page,
+  // read directly from screenshot pixels — see web-crawler/scrape_page.py's
+  // _dominant_flat_colors. `coverage` is a 0-1 fraction of sampled flat tiles.
+  pixelDominantColors?: { hex: string; coverage: number }[]
+  themeColor?: string | null
+  fonts?: { body?: string | null; heading?: string | null }
+  // `rect` is present for candidates found on the homepage (brand_probe.js);
+  // recurrence-only candidates folded in from other pages (scrape_page.py's
+  // _apply_logo_recurrence) have no single position and omit it.
+  logos?: {
+    url: string
+    kind: string
+    area?: number
+    score: number
+    rect?: PixelRect
+    recurringPages?: number
+  }[]
+  title?: string | null
 }
 
 /* A row of the demo_requests queue, written by the marketing site's /api/demo

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,12 @@ importers:
       express:
         specifier: ^4.21.2
         version: 4.21.2
+      node-vibrant:
+        specifier: ^4.0.4
+        version: 4.0.4
+      sharp:
+        specifier: ^0.35.3
+        version: 0.35.3(@types/node@20.17.30)
       zod:
         specifier: ^4.1.8
         version: 4.4.3
@@ -809,6 +815,9 @@ packages:
   '@emnapi/core@1.4.0':
     resolution: {integrity: sha512-H+N/FqT07NmLmt6OFFtDfwe8PNygprzBikrEMyQfgqSmT0vzE515Pz7R8izwB9q/zsH/MA64AKoul3sA6/CzVg==}
 
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+
   '@emnapi/runtime@1.4.0':
     resolution: {integrity: sha512-64WYIf4UYcdLnbKn/umDlNjQDSS8AgZrI/R9+x5ilkUVFxXcA1Ebl+gQLc/6mERA4407Xof0R7wEyEuj091CVw==}
 
@@ -1024,6 +1033,152 @@ packages:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
 
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.35.3':
+    resolution: {integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.35.3':
+    resolution: {integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    resolution: {integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
+    resolution: {integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.3.2':
+    resolution: {integrity: sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.3.2':
+    resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.3.2':
+    resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
+    resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
+    resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.3.2':
+    resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.3.2':
+    resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+    resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.35.3':
+    resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.35.3':
+    resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.35.3':
+    resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.35.3':
+    resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.35.3':
+    resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.35.3':
+    resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.35.3':
+    resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.35.3':
+    resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.35.3':
+    resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    resolution: {integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==}
+    engines: {node: '>=20.9.0'}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.35.3':
+    resolution: {integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.35.3':
+    resolution: {integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==}
+    engines: {node: ^20.9.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.35.3':
+    resolution: {integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [win32]
+
   '@inquirer/confirm@5.1.16':
     resolution: {integrity: sha512-j1a5VstaK5KQy8Mu8cHmuQvN1Zc62TbLhjJxwHvKPPKEoowSF6h/0UdOpA9DNdWZ+9Inq73+puRq1df6OJ8Sag==}
     engines: {node: '>=18'}
@@ -1070,6 +1225,50 @@ packages:
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
+
+  '@jimp/bmp@0.22.12':
+    resolution: {integrity: sha512-aeI64HD0npropd+AR76MCcvvRaa+Qck6loCOS03CkkxGHN5/r336qTM5HPUdHKMDOGzqknuVPA8+kK1t03z12g==}
+    peerDependencies:
+      '@jimp/custom': '>=0.3.5'
+
+  '@jimp/core@0.22.12':
+    resolution: {integrity: sha512-l0RR0dOPyzMKfjUW1uebzueFEDtCOj9fN6pyTYWWOM/VS4BciXQ1VVrJs8pO3kycGYZxncRKhCoygbNr8eEZQA==}
+
+  '@jimp/custom@0.22.12':
+    resolution: {integrity: sha512-xcmww1O/JFP2MrlGUMd3Q78S3Qu6W3mYTXYuIqFq33EorgYHV/HqymHfXy9GjiCJ7OI+7lWx6nYFOzU7M4rd1Q==}
+
+  '@jimp/gif@0.22.12':
+    resolution: {integrity: sha512-y6BFTJgch9mbor2H234VSjd9iwAhaNf/t3US5qpYIs0TSbAvM02Fbc28IaDETj9+4YB4676sz4RcN/zwhfu1pg==}
+    peerDependencies:
+      '@jimp/custom': '>=0.3.5'
+
+  '@jimp/jpeg@0.22.12':
+    resolution: {integrity: sha512-Rq26XC/uQWaQKyb/5lksCTCxXhtY01NJeBN+dQv5yNYedN0i7iYu+fXEoRsfaJ8xZzjoANH8sns7rVP4GE7d/Q==}
+    peerDependencies:
+      '@jimp/custom': '>=0.3.5'
+
+  '@jimp/plugin-resize@0.22.12':
+    resolution: {integrity: sha512-3NyTPlPbTnGKDIbaBgQ3HbE6wXbAlFfxHVERmrbqAi8R3r6fQPxpCauA8UVDnieg5eo04D0T8nnnNIX//i/sXg==}
+    peerDependencies:
+      '@jimp/custom': '>=0.3.5'
+
+  '@jimp/png@0.22.12':
+    resolution: {integrity: sha512-Mrp6dr3UTn+aLK8ty/dSKELz+Otdz1v4aAXzV5q53UDD2rbB5joKVJ/ChY310B+eRzNxIovbUF1KVrUsYdE8Hg==}
+    peerDependencies:
+      '@jimp/custom': '>=0.3.5'
+
+  '@jimp/tiff@0.22.12':
+    resolution: {integrity: sha512-E1LtMh4RyJsoCAfAkBRVSYyZDTtLq9p9LUiiYP0vPtXyxX4BiYBUYihTLSBlCQg5nF2e4OpQg7SPrLdJ66u7jg==}
+    peerDependencies:
+      '@jimp/custom': '>=0.3.5'
+
+  '@jimp/types@0.22.12':
+    resolution: {integrity: sha512-wwKYzRdElE1MBXFREvCto5s699izFHNVvALUv79GXNbsOVqlwlOxlWJ8DuyOGIXoLP4JW/m30YyuTtfUJgMRMA==}
+    peerDependencies:
+      '@jimp/custom': '>=0.3.5'
+
+  '@jimp/utils@0.22.12':
+    resolution: {integrity: sha512-yJ5cWUknGnilBq97ZXOyOS0HhsHOyAyjHwYfHxGbSyMTohgQI6sVyE8KPgDwH8HHW/nMKXk8TrSwAE71zt716Q==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1643,6 +1842,9 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
 
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
 
@@ -1747,6 +1949,12 @@ packages:
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
+  '@types/node@16.9.1':
+    resolution: {integrity: sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==}
+
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
   '@types/node@20.17.30':
     resolution: {integrity: sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==}
@@ -1941,6 +2149,39 @@ packages:
   '@upstash/vector@1.2.3':
     resolution: {integrity: sha512-yXsWKeuHNYyH72BcSZd3bV5ZD5MybAoTvKxkMaeV2UzuGfNzbHBVh5eO+ysTWTFAf8I9XcOueF4tZfAGjCa4Iw==}
 
+  '@vibrant/color@4.0.4':
+    resolution: {integrity: sha512-Fq2tAszz4QOPWfHZ+KuEAchXUD8i594BM2fOJt8dI/fvYbiVoBycBF/BlNH6F4IWBubxXoPqD4JmmAHvFYbNew==}
+
+  '@vibrant/core@4.0.4':
+    resolution: {integrity: sha512-yZ0XSpW2biKyaJPpBC31AVYgn7NseKSO2q3KNMmDrkL2qC6TEWsBMnSQ28n0m///chZELXpQLx1CCOsWg5pj8w==}
+
+  '@vibrant/generator-default@4.0.4':
+    resolution: {integrity: sha512-QeVDeH2dz9lityvJCb84Ml4hlBTElwCpU7SVpiDFBh6gPoCLnzcb1H9G4NgG3hOlAPyrBM+Ivq1Pg+1lZj5Ywg==}
+
+  '@vibrant/generator@4.0.4':
+    resolution: {integrity: sha512-rwq8PnlpKdch4YqaA1FAwdm71gKE2cMrUsbu72TqRFGa8rpP1roaZlQCVXIIwElXVc3r9axZyAcqyTLaMjhrTg==}
+
+  '@vibrant/image-browser@4.0.4':
+    resolution: {integrity: sha512-7qVyAm+z9t98iwMDzUgGCwgRg0KBB5RXQFgiO2Um5Izd1wO7BKC0SHVEz2k7sRx3XNfBf+JExp8quPrvSz17gg==}
+
+  '@vibrant/image-node@4.0.4':
+    resolution: {integrity: sha512-aG8Ukt9oTa6FWaAV5oBKsBetkKASWH31hZiFJ2R1291f3TZlphUyQTJz5TubucIRsCEl4dgG1xyxFPgse2IABA==}
+
+  '@vibrant/image@4.0.4':
+    resolution: {integrity: sha512-NBIJj7umfDRVpFjJHQo1AFSCWCzQyjfil+Yxu7W62PEL72GPCif0CDiglPkvVF8QhDLmnx/x1k3LIBb9jWF2sw==}
+
+  '@vibrant/quantizer-mmcq@4.0.4':
+    resolution: {integrity: sha512-/1CNnM96J8K+OBCWNUzywo6VdnmdFJyiKO+ty/nkfe8H0NseOEHIL7PrVtWGgtsb0rh2uTAq2rjXv65TfgPy8g==}
+
+  '@vibrant/quantizer@4.0.4':
+    resolution: {integrity: sha512-722CooC2W4mlBiv+zyAsIrIvARnMCN/P2Muo8bnWd0SQlVWFtQnFxJWGOUPOPS4DGe3pGoqmNfvS0let4dICZQ==}
+
+  '@vibrant/types@4.0.4':
+    resolution: {integrity: sha512-Qq3mVTJamn7yD4OBgBEUKaxfDlm3sxBK55N7dH3XzI9Ey7KR00R06uwtqOcEJMsziWTEXdYN3VUlYaj2Tkt7hw==}
+
+  '@vibrant/worker@4.0.4':
+    resolution: {integrity: sha512-Q/R6PYhSMWCXEk/IcXbWIzIu7Z4b58ABkGvcdF8Y+q/7g+KnpxKW5x/jfQ/6ciyYSby13wZZoEdNr3QQVgsdBQ==}
+
   '@vitejs/plugin-react@4.3.4':
     resolution: {integrity: sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -1964,6 +2205,10 @@ packages:
 
   '@yarnpkg/lockfile@1.1.0':
     resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
+
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -2032,6 +2277,9 @@ packages:
   ansis@4.1.0:
     resolution: {integrity: sha512-BGcItUBWSMRgOCe+SVZJ+S7yTRG0eGt9cXAHev72yuGcY23hnLA7Bky5L/xLyPINoSN95geovfBkqoTlNZYa7w==}
     engines: {node: '>=14'}
+
+  any-base@1.1.0:
+    resolution: {integrity: sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==}
 
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
@@ -2144,6 +2392,9 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  bmp-js@0.1.0:
+    resolution: {integrity: sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==}
+
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -2178,6 +2429,12 @@ packages:
 
   buffer@4.9.2:
     resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -2492,6 +2749,10 @@ packages:
 
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
+    engines: {node: '>=8'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   devlop@1.1.0:
@@ -2847,9 +3108,17 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   events@1.1.1:
     resolution: {integrity: sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==}
     engines: {node: '>=0.4.x'}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
 
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
@@ -2866,6 +3135,9 @@ packages:
   execa@9.6.0:
     resolution: {integrity: sha512-jpWzZ1ZhwUmeWRhS7Qv3mhpOhLfwI+uAX4e5fOcXqwMR7EcJ0pj2kV1CVzHVMX/LphnKWD3LObjZCoJ71lKpHw==}
     engines: {node: ^18.19.0 || >=20.5.0}
+
+  exif-parser@0.1.12:
+    resolution: {integrity: sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw==}
 
   expand-tilde@2.0.2:
     resolution: {integrity: sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==}
@@ -2933,6 +3205,10 @@ packages:
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
+
+  file-type@16.5.4:
+    resolution: {integrity: sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==}
+    engines: {node: '>=10'}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -3087,6 +3363,9 @@ packages:
   get-tsconfig@4.10.0:
     resolution: {integrity: sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==}
 
+  gifwrap@0.10.1:
+    resolution: {integrity: sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -3235,9 +3514,15 @@ packages:
   ieee754@1.1.13:
     resolution: {integrity: sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
+
+  image-q@4.0.0:
+    resolution: {integrity: sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -3466,6 +3751,9 @@ packages:
     resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
     engines: {node: '>=16'}
 
+  isomorphic-fetch@3.0.0:
+    resolution: {integrity: sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
@@ -3480,6 +3768,9 @@ packages:
   jmespath@0.16.0:
     resolution: {integrity: sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==}
     engines: {node: '>= 0.6.0'}
+
+  jpeg-js@0.4.4:
+    resolution: {integrity: sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3953,12 +4244,24 @@ packages:
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
+
+  node-vibrant@4.0.4:
+    resolution: {integrity: sha512-hA/pUXBE9TJ41G9FlTkzeqD5JdxgvvPGYZb/HNpdkaxxXUEnP36imSolZ644JuPun+lTd+FpWWtBpTYdp2noQA==}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -4018,6 +4321,9 @@ packages:
   object.values@1.2.1:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
+
+  omggif@1.0.10:
+    resolution: {integrity: sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -4112,6 +4418,9 @@ packages:
   package-manager-detector@1.3.0:
     resolution: {integrity: sha512-ZsEbbZORsyHuO00lY1kV3/t72yp6Ysay6Pd17ZAlNGuGwmWDLCJxFpRs0IzfXfj1o4icJOkUEioexFHzyPurSQ==}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -4189,6 +4498,10 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  peek-readable@4.1.0:
+    resolution: {integrity: sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==}
+    engines: {node: '>=8'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -4204,12 +4517,24 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
+  pixelmatch@4.0.2:
+    resolution: {integrity: sha512-J8B6xqiO37sU/gkcMglv6h5Jbd9xNER7aHzpfRdNmV4IbQBzBpe4l9XmbG+xPF/znacgu2jfEw+wHffaq/YkXA==}
+    hasBin: true
+
   pkce-challenge@5.0.0:
     resolution: {integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==}
     engines: {node: '>=16.20.0'}
 
   please-upgrade-node@3.2.0:
     resolution: {integrity: sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==}
+
+  pngjs@3.4.0:
+    resolution: {integrity: sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==}
+    engines: {node: '>=4.0.0'}
+
+  pngjs@6.0.0:
+    resolution: {integrity: sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==}
+    engines: {node: '>=12.13.0'}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -4247,6 +4572,10 @@ packages:
   proc-log@5.0.0:
     resolution: {integrity: sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
 
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -4340,6 +4669,14 @@ packages:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
 
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  readable-web-to-node-stream@3.0.4:
+    resolution: {integrity: sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==}
+    engines: {node: '>=8'}
+
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -4351,6 +4688,9 @@ packages:
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
+
+  regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
@@ -4479,6 +4819,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@0.19.0:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
@@ -4513,6 +4858,15 @@ packages:
   shadcn@3.0.0:
     resolution: {integrity: sha512-GhMwMwcxR3GpDO2ctocvyetQ7BJAxSakaznBtYM/1mPRTjN0I0TAZCGSXdfj0VXOW4PaHbFEHsyUCnFcEf/1Ag==}
     hasBin: true
+
+  sharp@0.35.3:
+    resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -4638,6 +4992,9 @@ packages:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
@@ -4672,6 +5029,10 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strtok3@6.3.0:
+    resolution: {integrity: sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==}
+    engines: {node: '>=10'}
 
   style-to-js@1.1.17:
     resolution: {integrity: sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA==}
@@ -4732,8 +5093,14 @@ packages:
     resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
     engines: {node: '>=18'}
 
+  timm@1.7.1:
+    resolution: {integrity: sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw==}
+
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
+  tinycolor2@1.6.0:
+    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
   tinyexec@1.0.1:
     resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
@@ -4764,6 +5131,10 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  token-types@4.2.1:
+    resolution: {integrity: sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==}
+    engines: {node: '>=10'}
 
   tough-cookie@6.0.0:
     resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
@@ -4932,6 +5303,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
@@ -4997,6 +5371,9 @@ packages:
     resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  utif2@4.1.0:
+    resolution: {integrity: sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==}
 
   util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
@@ -5084,6 +5461,9 @@ packages:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
     deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-fetch@3.6.20:
+    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -5863,6 +6243,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.11.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.4.0':
     dependencies:
       tslib: 2.8.1
@@ -6017,6 +6402,112 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+    optional: true
+
+  '@img/sharp-darwin-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-arm@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-s390x@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-wasm32@0.35.3':
+    dependencies:
+      '@emnapi/runtime': 1.11.2
+    optional: true
+
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
+    optional: true
+
+  '@img/sharp-win32-arm64@0.35.3':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.35.3':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.3':
+    optional: true
+
   '@inquirer/confirm@5.1.16(@types/node@20.17.30)':
     dependencies:
       '@inquirer/core': 10.2.0(@types/node@20.17.30)
@@ -6061,6 +6552,74 @@ snapshots:
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.2
+
+  '@jimp/bmp@0.22.12(@jimp/custom@0.22.12)':
+    dependencies:
+      '@jimp/custom': 0.22.12
+      '@jimp/utils': 0.22.12
+      bmp-js: 0.1.0
+
+  '@jimp/core@0.22.12':
+    dependencies:
+      '@jimp/utils': 0.22.12
+      any-base: 1.1.0
+      buffer: 5.7.1
+      exif-parser: 0.1.12
+      file-type: 16.5.4
+      isomorphic-fetch: 3.0.0
+      pixelmatch: 4.0.2
+      tinycolor2: 1.6.0
+    transitivePeerDependencies:
+      - encoding
+
+  '@jimp/custom@0.22.12':
+    dependencies:
+      '@jimp/core': 0.22.12
+    transitivePeerDependencies:
+      - encoding
+
+  '@jimp/gif@0.22.12(@jimp/custom@0.22.12)':
+    dependencies:
+      '@jimp/custom': 0.22.12
+      '@jimp/utils': 0.22.12
+      gifwrap: 0.10.1
+      omggif: 1.0.10
+
+  '@jimp/jpeg@0.22.12(@jimp/custom@0.22.12)':
+    dependencies:
+      '@jimp/custom': 0.22.12
+      '@jimp/utils': 0.22.12
+      jpeg-js: 0.4.4
+
+  '@jimp/plugin-resize@0.22.12(@jimp/custom@0.22.12)':
+    dependencies:
+      '@jimp/custom': 0.22.12
+      '@jimp/utils': 0.22.12
+
+  '@jimp/png@0.22.12(@jimp/custom@0.22.12)':
+    dependencies:
+      '@jimp/custom': 0.22.12
+      '@jimp/utils': 0.22.12
+      pngjs: 6.0.0
+
+  '@jimp/tiff@0.22.12(@jimp/custom@0.22.12)':
+    dependencies:
+      '@jimp/custom': 0.22.12
+      utif2: 4.1.0
+
+  '@jimp/types@0.22.12(@jimp/custom@0.22.12)':
+    dependencies:
+      '@jimp/bmp': 0.22.12(@jimp/custom@0.22.12)
+      '@jimp/custom': 0.22.12
+      '@jimp/gif': 0.22.12(@jimp/custom@0.22.12)
+      '@jimp/jpeg': 0.22.12(@jimp/custom@0.22.12)
+      '@jimp/png': 0.22.12(@jimp/custom@0.22.12)
+      '@jimp/tiff': 0.22.12(@jimp/custom@0.22.12)
+      timm: 1.7.1
+
+  '@jimp/utils@0.22.12':
+    dependencies:
+      regenerator-runtime: 0.13.11
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -6595,6 +7154,8 @@ snapshots:
       tailwindcss: 4.1.12
       vite: 6.2.5(@types/node@20.17.30)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1)
 
+  '@tokenizer/token@0.3.0': {}
+
   '@ts-morph/common@0.27.0':
     dependencies:
       fast-glob: 3.3.3
@@ -6726,6 +7287,12 @@ snapshots:
   '@types/ms@2.1.0': {}
 
   '@types/node@12.20.55': {}
+
+  '@types/node@16.9.1': {}
+
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
 
   '@types/node@20.17.30':
     dependencies:
@@ -6908,6 +7475,61 @@ snapshots:
 
   '@upstash/vector@1.2.3': {}
 
+  '@vibrant/color@4.0.4': {}
+
+  '@vibrant/core@4.0.4':
+    dependencies:
+      '@vibrant/color': 4.0.4
+      '@vibrant/generator': 4.0.4
+      '@vibrant/image': 4.0.4
+      '@vibrant/quantizer': 4.0.4
+      '@vibrant/worker': 4.0.4
+
+  '@vibrant/generator-default@4.0.4':
+    dependencies:
+      '@vibrant/color': 4.0.4
+      '@vibrant/generator': 4.0.4
+
+  '@vibrant/generator@4.0.4':
+    dependencies:
+      '@vibrant/color': 4.0.4
+      '@vibrant/types': 4.0.4
+
+  '@vibrant/image-browser@4.0.4':
+    dependencies:
+      '@vibrant/image': 4.0.4
+
+  '@vibrant/image-node@4.0.4':
+    dependencies:
+      '@jimp/custom': 0.22.12
+      '@jimp/plugin-resize': 0.22.12(@jimp/custom@0.22.12)
+      '@jimp/types': 0.22.12(@jimp/custom@0.22.12)
+      '@vibrant/image': 4.0.4
+    transitivePeerDependencies:
+      - encoding
+
+  '@vibrant/image@4.0.4':
+    dependencies:
+      '@vibrant/color': 4.0.4
+
+  '@vibrant/quantizer-mmcq@4.0.4':
+    dependencies:
+      '@vibrant/color': 4.0.4
+      '@vibrant/image': 4.0.4
+      '@vibrant/quantizer': 4.0.4
+
+  '@vibrant/quantizer@4.0.4':
+    dependencies:
+      '@vibrant/color': 4.0.4
+      '@vibrant/image': 4.0.4
+      '@vibrant/types': 4.0.4
+
+  '@vibrant/types@4.0.4': {}
+
+  '@vibrant/worker@4.0.4':
+    dependencies:
+      '@vibrant/types': 4.0.4
+
   '@vitejs/plugin-react@4.3.4(vite@6.2.5(@types/node@20.17.30)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1))':
     dependencies:
       '@babel/core': 7.26.10
@@ -6952,6 +7574,10 @@ snapshots:
   '@vue/shared@3.5.20': {}
 
   '@yarnpkg/lockfile@1.1.0': {}
+
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
 
   accepts@1.3.8:
     dependencies:
@@ -7025,6 +7651,8 @@ snapshots:
   ansi-styles@6.2.1: {}
 
   ansis@4.1.0: {}
+
+  any-base@1.1.0: {}
 
   anymatch@3.1.3:
     dependencies:
@@ -7175,6 +7803,8 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  bmp-js@0.1.0: {}
+
   body-parser@1.20.3:
     dependencies:
       bytes: 3.1.2
@@ -7237,6 +7867,16 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.1.13
       isarray: 1.0.0
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.1.13
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   bytes@3.1.2: {}
 
@@ -7538,6 +8178,8 @@ snapshots:
   detect-indent@6.1.0: {}
 
   detect-libc@2.0.4: {}
+
+  detect-libc@2.1.2: {}
 
   devlop@1.1.0:
     dependencies:
@@ -8024,7 +8666,11 @@ snapshots:
 
   etag@1.8.1: {}
 
+  event-target-shim@5.0.1: {}
+
   events@1.1.1: {}
+
+  events@3.3.0: {}
 
   eventsource-parser@3.0.6: {}
 
@@ -8058,6 +8704,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
+
+  exif-parser@0.1.12: {}
 
   expand-tilde@2.0.2:
     dependencies:
@@ -8185,6 +8833,12 @@ snapshots:
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
+
+  file-type@16.5.4:
+    dependencies:
+      readable-web-to-node-stream: 3.0.4
+      strtok3: 6.3.0
+      token-types: 4.2.1
 
   fill-range@7.1.1:
     dependencies:
@@ -8361,6 +9015,11 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  gifwrap@0.10.1:
+    dependencies:
+      image-q: 4.0.0
+      omggif: 1.0.10
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -8534,7 +9193,13 @@ snapshots:
 
   ieee754@1.1.13: {}
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
+
+  image-q@4.0.0:
+    dependencies:
+      '@types/node': 16.9.1
 
   import-fresh@3.3.1:
     dependencies:
@@ -8737,6 +9402,13 @@ snapshots:
 
   isexe@3.1.1: {}
 
+  isomorphic-fetch@3.0.0:
+    dependencies:
+      node-fetch: 2.7.0
+      whatwg-fetch: 3.6.20
+    transitivePeerDependencies:
+      - encoding
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -8755,6 +9427,8 @@ snapshots:
   jiti@2.5.1: {}
 
   jmespath@0.16.0: {}
+
+  jpeg-js@0.4.4: {}
 
   js-tokens@4.0.0: {}
 
@@ -9307,6 +9981,10 @@ snapshots:
 
   node-domexception@1.0.0: {}
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-fetch@3.3.2:
     dependencies:
       data-uri-to-buffer: 4.0.1
@@ -9314,6 +9992,17 @@ snapshots:
       formdata-polyfill: 4.0.10
 
   node-releases@2.0.19: {}
+
+  node-vibrant@4.0.4:
+    dependencies:
+      '@types/node': 18.19.130
+      '@vibrant/core': 4.0.4
+      '@vibrant/generator-default': 4.0.4
+      '@vibrant/image-browser': 4.0.4
+      '@vibrant/image-node': 4.0.4
+      '@vibrant/quantizer-mmcq': 4.0.4
+    transitivePeerDependencies:
+      - encoding
 
   normalize-path@3.0.0: {}
 
@@ -9377,6 +10066,8 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  omggif@1.0.10: {}
 
   on-finished@2.4.1:
     dependencies:
@@ -9475,6 +10166,8 @@ snapshots:
 
   package-manager-detector@1.3.0: {}
 
+  pako@1.0.11: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -9557,6 +10250,8 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  peek-readable@4.1.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -9565,11 +10260,19 @@ snapshots:
 
   pify@4.0.1: {}
 
+  pixelmatch@4.0.2:
+    dependencies:
+      pngjs: 3.4.0
+
   pkce-challenge@5.0.0: {}
 
   please-upgrade-node@3.2.0:
     dependencies:
       semver-compare: 1.0.0
+
+  pngjs@3.4.0: {}
+
+  pngjs@6.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
 
@@ -9596,6 +10299,8 @@ snapshots:
       parse-ms: 4.0.0
 
   proc-log@5.0.0: {}
+
+  process@0.11.10: {}
 
   prompts@2.4.2:
     dependencies:
@@ -9695,6 +10400,18 @@ snapshots:
       pify: 4.0.1
       strip-bom: 3.0.0
 
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+
+  readable-web-to-node-stream@3.0.4:
+    dependencies:
+      readable-stream: 4.7.0
+
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
@@ -9717,6 +10434,8 @@ snapshots:
       get-intrinsic: 1.3.0
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
+
+  regenerator-runtime@0.13.11: {}
 
   regenerator-runtime@0.14.1: {}
 
@@ -9872,6 +10591,8 @@ snapshots:
 
   semver@7.7.1: {}
 
+  semver@7.8.5: {}
+
   send@0.19.0:
     dependencies:
       debug: 2.6.9
@@ -9983,6 +10704,39 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - typescript
+
+  sharp@0.35.3(@types/node@20.17.30):
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.3
+      '@img/sharp-darwin-x64': 0.35.3
+      '@img/sharp-freebsd-wasm32': 0.35.3
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+      '@img/sharp-libvips-darwin-x64': 1.3.2
+      '@img/sharp-libvips-linux-arm': 1.3.2
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+      '@img/sharp-libvips-linux-x64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+      '@img/sharp-linux-arm': 0.35.3
+      '@img/sharp-linux-arm64': 0.35.3
+      '@img/sharp-linux-ppc64': 0.35.3
+      '@img/sharp-linux-riscv64': 0.35.3
+      '@img/sharp-linux-s390x': 0.35.3
+      '@img/sharp-linux-x64': 0.35.3
+      '@img/sharp-linuxmusl-arm64': 0.35.3
+      '@img/sharp-linuxmusl-x64': 0.35.3
+      '@img/sharp-webcontainers-wasm32': 0.35.3
+      '@img/sharp-win32-arm64': 0.35.3
+      '@img/sharp-win32-ia32': 0.35.3
+      '@img/sharp-win32-x64': 0.35.3
+      '@types/node': 20.17.30
 
   shebang-command@2.0.0:
     dependencies:
@@ -10131,6 +10885,10 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
@@ -10159,6 +10917,11 @@ snapshots:
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
+
+  strtok3@6.3.0:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+      peek-readable: 4.1.0
 
   style-to-js@1.1.17:
     dependencies:
@@ -10222,7 +10985,11 @@ snapshots:
 
   throttleit@2.1.0: {}
 
+  timm@1.7.1: {}
+
   tiny-invariant@1.3.3: {}
+
+  tinycolor2@1.6.0: {}
 
   tinyexec@1.0.1: {}
 
@@ -10248,6 +11015,11 @@ snapshots:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
+
+  token-types@4.2.1:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
 
   tough-cookie@6.0.0:
     dependencies:
@@ -10448,6 +11220,8 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
+  undici-types@5.26.5: {}
+
   undici-types@6.19.8: {}
 
   undici@7.28.0: {}
@@ -10534,6 +11308,10 @@ snapshots:
     dependencies:
       react: 19.1.0
 
+  utif2@4.1.0:
+    dependencies:
+      pako: 1.0.11
+
   util@0.12.5:
     dependencies:
       inherits: 2.0.4
@@ -10586,6 +11364,8 @@ snapshots:
   whatwg-encoding@3.1.1:
     dependencies:
       iconv-lite: 0.6.3
+
+  whatwg-fetch@3.6.20: {}
 
   whatwg-mimetype@4.0.0: {}
 


### PR DESCRIPTION
## Summary
Companion to [Untap-AI/web-crawler#16](https://github.com/Untap-AI/web-crawler/pull/16), which adds the live-DOM brand probe this consumes.

- **Color detection**: vision picks from a ranked, annotated candidate pool (pixel-dominant page coverage, CSS variables, computed styles, logo-sampled color) instead of guessing from HTML regex matches. Fixed a real case (West Hills Vineyards) where the model picked a minor accent shade over the site's actual dominant color because nothing told it *why* each candidate was there — candidates now carry a note (e.g. "covers 52% of the rendered page") so it can prefer measured page coverage over a generic CSS variable name.
- **Logo color sampling**: `sample-logo-color.ts` now uses `node-vibrant` (same algorithm as Android's Palette API) instead of a hand-rolled histogram, which was fooled by garbage RGB values left under fully-transparent PNG regions.
- **Dynamic header theme**: `detect-brand.ts` now picks `primary` (colored header) vs `secondary` (white header) per demo by comparing the logo's own ink luminance against each — a logo drawn as white-only art no longer risks going invisible on a white header. Only one theme is built/uploaded now; the previously-unused second variant (nothing ever linked to it) is gone.
- **Secondary color**: no longer guessed — it only ever painted the chat bubble, and a wrong guess (dark color + fixed dark text) read worse than the widget's own neutral default. Caller-supplied overrides still go through a contrast guard.
- **Welcome message / suggestions**: now require markdown structure, short button labels distinct from the full question text, and explicit grounding in the scraped content.
- **Email**: the "demo ready" email is now rendered from an in-repo template (`email-templates.ts`) instead of referencing an opaque SendGrid dynamic template ID, and a "demo is being created" confirmation now fires as soon as a request is claimed off the queue.
- Raises crawl depth/page limits and analysis page count to match the web-crawler side's deeper, faster crawl.

## Test plan
- [x] `pnpm --filter demo-setup build` passes
- [x] Ran the full pipeline against 4 real small-business sites on different platforms (Wix, Shopify, Squarespace, custom) via a local harness bypassing the queue, and manually verified generated colors/logos/theme against each live site
- [x] Confirmed the dynamic theme picker against a known white-only logo (correctly kept the colored header) and a known dark-on-white logo (correctly switched to the white header)
- [ ] Merge companion web-crawler PR first — this pipeline depends on `brand_probe.js`/`logo_probe.js` fields in the scrape payload