### PR TITLE
chore(demo-setup): lower default RAG crawl page cap 100 → 50

### DIFF
--- a/apps/demo-setup/src/config/env.ts
+++ b/apps/demo-setup/src/config/env.ts
@@ -93,7 +93,7 @@ export const env = {
   // Hard cap on pages visited by the deep RAG crawl. Depth alone isn't a bound —
   // depth 1 on a site with a large footer nav could otherwise be hundreds of
   // pages.
-  crawlerMaxPages: optional('CRAWLER_MAX_PAGES', '100'),
+  crawlerMaxPages: optional('CRAWLER_MAX_PAGES', '50'),
 
   // Number of pages the shallow demo-prep scrape fetches (homepage + internal
   // links, ranked by relevance — see web-crawler/scrape_page.py's PATH_PRIORITIES).


### PR DESCRIPTION
## Summary
- Lowers the default `CRAWLER_MAX_PAGES` (hard cap on pages visited by the deep RAG crawl) from 100 to 50, to trim crawl time and LLM summarization cost for the small-business sites this pipeline targets.

## Test plan
- [x] `pnpm --filter demo-setup build` passes
- [ ] Verify crawl time/vector count on a real demo after merge