### PR TITLE
fix: prevent !important scrollbar-thin utility from re-enabling native scrollbar on Radix viewport

### DIFF
--- a/.changeset/fix-radix-viewport-scrollbar-important.md
+++ b/.changeset/fix-radix-viewport-scrollbar-important.md
@@ -1,0 +1,5 @@
+---
+"@dialogue-foundry/frontend": patch
+---
+
+Fix suggestions scrollbar still showing double scrollbars in Chromium browsers: a global `!important` `scrollbar-width: thin` utility applied to every widget descendant was overriding Radix ScrollArea's native-scrollbar-hiding styles now that Chromium supports the standard `scrollbar-width` property

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -110,6 +110,20 @@
   #dialogue-foundry-app [hidden]:where(:not([hidden="until-found"])) {
     display: none !important;
   }
+
+  /* ChatWidget applies `df:[&_*]:scrollbar-thin` (and friends) to every descendant to skin
+     scrollbars app-wide; Tailwind's `important` import (index.css line 3) makes that
+     `!important`. Modern Chromium now honors the standard `scrollbar-width` property, so
+     without this override it re-enables a native scrollbar on top of the Radix ScrollArea's
+     own custom thumb. `!important` in an earlier layer beats `!important` in a later one
+     regardless of specificity, so this must stay inside `@layer base`. */
+  [data-radix-scroll-area-viewport] {
+    scrollbar-width: none !important;
+  }
+
+  [data-radix-scroll-area-viewport]::-webkit-scrollbar {
+    display: none !important;
+  }
 }
 
 @theme {


### PR DESCRIPTION
## Summary
- Follow-up to #74. That PR fixed a global `#dialogue-foundry-app ::-webkit-scrollbar` rule that was overriding Radix's scrollbar-hiding CSS, but the double scrollbar on the suggestions list persisted because of a **second, independent** override: `ChatWidget.tsx` applies `df:[&_*]:scrollbar-thin` to every descendant, and Tailwind's `important` utilities import compiles that to `scrollbar-width: thin !important`.
- Modern Chromium now supports the standard `scrollbar-width` property (previously Firefox-only), so this `!important` rule was forcing a native scrollbar back onto the Radix ScrollArea viewport, stacked on top of Radix's own custom thumb. Non-`!important` CSS can never beat this regardless of specificity.
- Adds an `!important` override scoped to `[data-radix-scroll-area-viewport]` inside `@layer base` in `apps/frontend/src/index.css`. Per the CSS cascade-layers spec, `!important` declarations reverse layer priority — an earlier layer's `!important` (`base`) beats a later layer's `!important` (`utilities`), regardless of selector specificity.
- Includes a changeset for the widget release.

## Test plan
- [x] `pnpm run build` passes
- [ ] Manually verify only Radix's custom scrollbar renders on the suggestions list in Chrome/Edge and Firefox after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)