### PR TITLE
chore: version frontend 0.4.68 -> 0.4.69 (radix viewport scrollbar fix)

### DIFF
--- a/.changeset/fix-radix-viewport-scrollbar-important.md
+++ b/.changeset/fix-radix-viewport-scrollbar-important.md
@@ -1,5 +1,0 @@
----
-"@dialogue-foundry/frontend": patch
----
-
-Fix suggestions scrollbar still showing double scrollbars in Chromium browsers: a global `!important` `scrollbar-width: thin` utility applied to every widget descendant was overriding Radix ScrollArea's native-scrollbar-hiding styles now that Chromium supports the standard `scrollbar-width` property

--- a/apps/frontend/CHANGELOG.md
+++ b/apps/frontend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @dialogue-foundry/frontend
 
+## 0.4.69
+
+### Patch Changes
+
+- 5704856: Fix suggestions scrollbar still showing double scrollbars in Chromium browsers: a global `!important` `scrollbar-width: thin` utility applied to every widget descendant was overriding Radix ScrollArea's native-scrollbar-hiding styles now that Chromium supports the standard `scrollbar-width` property
+
 ## 0.4.68
 
 ### Patch Changes

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dialogue-foundry/frontend",
   "private": true,
-  "version": "0.4.68",
+  "version": "0.4.69",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- #80 merged the Radix viewport scrollbar `!important` fix, but its changeset was never consumed via `pnpm changeset:version`, so `package.json` stayed at `0.4.68` — identical to the previous release (#74).
- The version-based S3 deploy script (`packages/deploy-s3/src/version-based-deploy.ts:182-185`) only updates the `0.4/` folder — which the embed script `0.4/index.js` points to — when the patch version changes. Since the version was unchanged, the fix was built and uploaded to `latest/` but never reached `0.4/`, so it silently never shipped to production.
- This applies the missing version bump (`0.4.68` → `0.4.69`) so the next deploy actually updates `0.4/index.js`.

## Test plan
- [x] `pnpm run build` passes
- [x] Verified the built bundle contains the `!important` scrollbar override from #80
- [ ] After merge, verify `https://djwdzs5n3r4m2.cloudfront.net/0.4/index.js` last-modified/etag updates and only one scrollbar renders on the suggestions list

🤖 Generated with [Claude Code](https://claude.com/claude-code)