### PR TITLE
feat(demo-setup): derive company name from URL, collapse to single email

### DIFF
--- a/apps/backend/supabase/migrations/20260709000000_demo_requests_company_name_nullable.sql
+++ b/apps/backend/supabase/migrations/20260709000000_demo_requests_company_name_nullable.sql
@@ -1,0 +1,12 @@
+-- Demo Requests: company_name becomes optional
+--
+-- The marketing site's demo form no longer collects a company name -- only
+-- a website URL. The demo-setup worker now derives the company name itself
+-- (from the business-name extraction already run during the crawl, falling
+-- back to the site's own branding/title, falling back to the domain), and
+-- writes it back onto this row once known. Until that happens the column is
+-- simply null.
+
+ALTER TABLE demo_requests ALTER COLUMN company_name DROP NOT NULL;
+
+COMMENT ON COLUMN demo_requests.company_name IS 'Optional going forward -- the marketing site no longer collects this. Null until the demo-setup worker derives it from the crawl and writes it back.';

--- a/apps/backend/supabase/migrations/20260709010000_demo_requests_collapse_email.sql
+++ b/apps/backend/supabase/migrations/20260709010000_demo_requests_collapse_email.sql
@@ -1,0 +1,49 @@
+-- Demo Requests: collapse contact_email + delivery_email into a single email
+--
+-- The marketing site's demo form now collects exactly one email address, which
+-- serves both purposes it used to split: it becomes chat_configs.support_email
+-- for the generated demo AND is where the "your demo is ready" link is sent.
+-- The two columns have been identical for every row written since the form was
+-- simplified, so keep contact_email's value (the one the pipeline maps to
+-- support_email), rename it to the now-generic `email`, and drop delivery_email.
+--
+-- Historical rows where the two differed are all completed/failed, and the
+-- rate-limit query only looks back 24h, so nothing operational is lost.
+
+-- Rename contact_email -> email (only if not already done, so this is re-runnable).
+-- The inline char_length CHECK and the format CHECK expression both auto-follow
+-- the rename; only the format constraint's *name* is stale, fixed below.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'demo_requests' AND column_name = 'contact_email'
+    ) AND NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'demo_requests' AND column_name = 'email'
+    ) THEN
+        ALTER TABLE demo_requests RENAME COLUMN contact_email TO email;
+    END IF;
+END $$;
+
+-- Dropping the column also drops its inline char_length CHECK, its named
+-- format-check constraint, and idx_demo_requests_delivery_email.
+ALTER TABLE demo_requests DROP COLUMN IF EXISTS delivery_email;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'demo_requests_contact_email_format_check'
+    ) THEN
+        ALTER TABLE demo_requests
+            RENAME CONSTRAINT demo_requests_contact_email_format_check
+            TO demo_requests_email_format_check;
+    END IF;
+END $$;
+
+-- The daily-per-address rate limit used to query delivery_email (now dropped).
+-- It queries `email` now, so give that lookup its own index.
+CREATE INDEX IF NOT EXISTS idx_demo_requests_email ON demo_requests (email);
+
+COMMENT ON COLUMN demo_requests.email IS 'The prospect''s email. Becomes chat_configs.support_email for the generated demo and is where the "your demo is ready" link is sent. The form collects a single address for both.';

--- a/apps/demo-setup/README.md
+++ b/apps/demo-setup/README.md
@@ -44,6 +44,10 @@ retained for backwards compatibility and holds the Upstash namespace
 }
 ```
 
+`companyName` is optional — like `logoUrl`/`title`, omit it and the pipeline
+infers one from the crawl (business-name extraction, then the site's own
+branding/title, then the domain) instead of using the supplied value verbatim.
+
 Returns `201 { "demoUrl": "https://demo.untap-ai.com/acme-1234/" }`. The demo is
 live immediately; RAG answers become available once the background crawl
 finishes.

--- a/apps/demo-setup/src/integrations/email-templates.ts
+++ b/apps/demo-setup/src/integrations/email-templates.ts
@@ -16,14 +16,21 @@ const escapeHtml = (value: string): string =>
 
 export const DEMO_READY_SUBJECT = 'Your Personalized Demo is Ready!'
 
-export const renderDemoReadyEmail = ({ demoUrl }: { demoUrl: string }): { html: string; text: string } => {
+export const renderDemoReadyEmail = ({
+  demoUrl,
+  companyName
+}: {
+  demoUrl: string
+  companyName: string
+}): { html: string; text: string } => {
   const safeUrl = escapeHtml(demoUrl)
   const displayUrl = demoUrl.replace(/^https?:\/\//, '')
+  const safeName = escapeHtml(companyName)
 
   const html = `<div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; color: #222;">
   <h2 style="color: #465cff; margin-bottom: 20px;">Your Personalized Demo is Ready!</h2>
 
-  <p style="margin-bottom: 15px;">Thank you for your interest in <strong>Untap AI!</strong> We've prepared your personalized AI assistant demo as requested.</p>
+  <p style="margin-bottom: 15px;">Thank you for your interest in <strong>Untap AI!</strong> We've prepared your personalized AI assistant demo for <strong>${safeName}</strong> as requested.</p>
 
   <p style="margin-bottom: 15px;">
     <strong>Your live demo:</strong><br>
@@ -47,7 +54,7 @@ export const renderDemoReadyEmail = ({ demoUrl }: { demoUrl: string }): { html: 
   </p>
 </div>`
 
-  const text = `Thank you for your interest in Untap AI! We've prepared your personalized AI assistant demo as requested.
+  const text = `Thank you for your interest in Untap AI! We've prepared your personalized AI assistant demo for ${companyName} as requested.
 
 Your live demo: ${demoUrl}
 
@@ -68,15 +75,16 @@ Questions? Reply to this email or contact us at contact@untap-ai.com`
  * their submission went anywhere during the ~30 minute build. */
 export const DEMO_PENDING_SUBJECT = 'Your Personalized Demo is Being Created'
 
-export const renderDemoPendingEmail = ({ companyName }: { companyName: string }): { html: string; text: string } => {
-  const safeName = escapeHtml(companyName)
+export const renderDemoPendingEmail = ({ websiteUrl }: { websiteUrl: string }): { html: string; text: string } => {
+  const displayUrl = websiteUrl.replace(/^https?:\/\//, '')
+  const safeDisplayUrl = escapeHtml(displayUrl)
 
   const html = `<div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
   <h2 style="color: #465cff; margin-bottom: 20px;">Your Personalized Demo is Being Created</h2>
 
   <p style="margin-bottom: 15px;">Hi there!</p>
 
-  <p style="margin-bottom: 15px;">We've received your request for a personalized demo for <strong>${safeName}</strong>.</p>
+  <p style="margin-bottom: 15px;">We've received your request for a personalized demo for <strong>${safeDisplayUrl}</strong>.</p>
 
   <p style="margin-bottom: 15px;">Our team is now training your AI assistant on your website's content and styling it to match your brand. This usually takes about <strong>30 minutes</strong>.</p>
 
@@ -99,7 +107,7 @@ export const renderDemoPendingEmail = ({ companyName }: { companyName: string })
 
   const text = `Hi there!
 
-We've received your request for a personalized demo for ${companyName}.
+We've received your request for a personalized demo for ${displayUrl}.
 
 Our team is now training your AI assistant on your website's content and styling it to match your brand. This usually takes about 30 minutes.
 

--- a/apps/demo-setup/src/integrations/sendgrid.ts
+++ b/apps/demo-setup/src/integrations/sendgrid.ts
@@ -37,11 +37,13 @@ const client = (): typeof sgMail | undefined => {
 export const sendDemoReadyEmail = async ({
   to,
   companyId,
-  demoUrl
+  demoUrl,
+  companyName
 }: {
   to: string
   companyId: string
   demoUrl: string
+  companyName: string
 }): Promise<boolean> => {
   const mail = client()
   if (!mail) {
@@ -51,7 +53,7 @@ export const sendDemoReadyEmail = async ({
     return false
   }
 
-  const { html, text } = renderDemoReadyEmail({ demoUrl })
+  const { html, text } = renderDemoReadyEmail({ demoUrl, companyName })
 
   try {
     await mail.send({
@@ -82,11 +84,11 @@ export const sendDemoReadyEmail = async ({
 export const sendDemoPendingEmail = async ({
   to,
   companyId,
-  companyName
+  websiteUrl
 }: {
   to: string
   companyId: string
-  companyName: string
+  websiteUrl: string
 }): Promise<boolean> => {
   const mail = client()
   if (!mail) {
@@ -96,7 +98,7 @@ export const sendDemoPendingEmail = async ({
     return false
   }
 
-  const { html, text } = renderDemoPendingEmail({ companyName })
+  const { html, text } = renderDemoPendingEmail({ websiteUrl })
 
   try {
     await mail.send({

--- a/apps/demo-setup/src/lib/slug.ts
+++ b/apps/demo-setup/src/lib/slug.ts
@@ -4,44 +4,55 @@ import { randomBytes } from 'node:crypto'
 // and demo_requests' 100-char company_id limit.
 const MAX_SLUG_BODY = 40
 
-// Latin letters that NFKD leaves alone because they're distinct letters rather
-// than a base plus a combining mark. Without these, "Ø" becomes "-", not "o".
-const LATIN_FOLD: Record<string, string> = {
-  ø: 'o',
-  æ: 'ae',
-  œ: 'oe',
-  ð: 'd',
-  þ: 'th',
-  ł: 'l',
-  đ: 'd',
-  ß: 'ss'
+/* Extracts the registrable label from a website URL for slugging/display —
+ * "https://www.acme-roofing.com/path" -> "acme-roofing". Falls back to
+ * undefined for anything that isn't a parseable URL, rather than throwing:
+ * the caller has its own fallback for that case, and the pipeline's own URL
+ * validation (assertSafeUrl) is what should surface a real error to the
+ * prospect. */
+const hostnameLabel = (websiteUrl: string): string | undefined => {
+  try {
+    const withProtocol = /^https?:\/\//i.test(websiteUrl)
+      ? websiteUrl
+      : `https://${websiteUrl}`
+    const host = new URL(withProtocol).hostname.replace(/^www\./i, '')
+    // Strip the TLD (last dot-segment) so "acme-roofing.com" -> "acme-roofing"
+    // rather than "acme-roofing-com".
+    const label = host.includes('.')
+      ? host.slice(0, host.lastIndexOf('.'))
+      : host
+    return label || undefined
+  } catch {
+    return undefined
+  }
 }
 
-/* Derives the company id for a demo request.
+/* Derives the company id for a demo request from its website URL.
  *
  * Two things depend on the exact output: it is the S3 key prefix the demo is
  * uploaded under, and it is the only variable the "demo ready" SendGrid template
  * receives — the template builds demo.untap-ai.com/{{company_id}}/ from it. A
  * change here is a change to the link the prospect clicks.
  *
+ * Derived from the URL rather than the company name because it has to exist
+ * before anything is scraped — the prospect no longer supplies a name up
+ * front, and the slug is needed immediately on claim (S3 prefix, Upstash
+ * namespace) well before the pipeline gets around to inferring one.
+ *
  * The "demo-" prefix keeps generated demos in a namespace of their own. Without
- * it a prospect named "Acme" would slug to `acme` and the pipeline's upsert into
+ * it a site at "acme.com" would slug to `acme` and the pipeline's upsert into
  * `companies` / `chat_configs` would silently overwrite a real customer's
  * system prompt and vector namespace.
  *
- * The random suffix means two prospects with the same company name never collide
- * (and no pre-flight SELECT is needed, so there's no check-then-insert race).
- * It is 4 bytes rather than 2 because a collision is not a retry — the second
- * demo would upsert over the first's chat_config and S3 objects, leaving the
- * first prospect's link serving someone else's company. */
-export const deriveCompanyId = (companyName: string): string => {
-  const body = companyName
-    // Fold accents to ASCII first, so "Ünïcødé Çafé" slugs to "unicode-cafe"
-    // rather than "n-c-d-af". The result is the URL the prospect clicks.
-    .normalize('NFKD')
-    .replace(/[̀-ͯ]/g, '')
+ * The random suffix means two prospects on the same domain (or a retry with a
+ * fresh URL) never collide (and no pre-flight SELECT is needed, so there's no
+ * check-then-insert race). It is 4 bytes rather than 2 because a collision is
+ * not a retry — the second demo would upsert over the first's chat_config and
+ * S3 objects, leaving the first prospect's link serving someone else's company. */
+export const deriveCompanyId = (websiteUrl: string): string => {
+  const label = hostnameLabel(websiteUrl)
+  const body = (label ?? '')
     .toLowerCase()
-    .replace(/[øæœðþłđß]/g, char => LATIN_FOLD[char])
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
     .slice(0, MAX_SLUG_BODY)
@@ -50,6 +61,20 @@ export const deriveCompanyId = (companyName: string): string => {
 
   const suffix = randomBytes(4).toString('hex')
 
-  // Names with nothing ASCII-alphanumeric in them (e.g. all-CJK) slug to empty.
+  // Unparseable URLs, or hosts with nothing ASCII-alphanumeric in them, slug
+  // to empty.
   return body ? `demo-${body}-${suffix}` : `demo-${suffix}`
+}
+
+/* Title-cases a hostname label for use as a last-resort company name when
+ * neither the content analysis nor the brand probe turned one up —
+ * "acme-roofing" -> "Acme Roofing". */
+export const titleCaseFromHostname = (websiteUrl: string): string => {
+  const label = hostnameLabel(websiteUrl)
+  if (!label) return 'Your Company'
+
+  return label
+    .replace(/[-_]+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, character => character.toUpperCase())
 }

--- a/apps/demo-setup/src/pipeline/run-pipeline.ts
+++ b/apps/demo-setup/src/pipeline/run-pipeline.ts
@@ -4,6 +4,7 @@ import { persistCompanyConfig } from '../integrations/supabase'
 import { uploadDemo } from '../integrations/s3'
 import { runCrawl } from '../integrations/crawler'
 import { scrapeForDemo } from '../integrations/scraper'
+import { titleCaseFromHostname } from '../lib/slug'
 import { prepareInput } from './prepare-input'
 import { extractBrandCandidates } from './extract-brand-candidates'
 import { analyzeContent } from './analyze-content'
@@ -11,16 +12,41 @@ import { detectBrand } from './detect-brand'
 import { enforceQuality } from './quality'
 import { buildSystemPrompt } from './system-prompt'
 import { buildHtml } from './build-html'
-import type { DemoInput } from '../types'
+import type {
+  BrandProbe,
+  ContentAnalysis,
+  DemoInput,
+  PreparedInput
+} from '../types'
 
 export type PipelineResult = {
   demoUrl: string
+  /* The name actually used to brand this demo — whatever the caller supplied,
+   * or whatever was inferred (see resolveCompanyName below). The queue worker
+   * writes this back onto the demo_requests row once known. */
+  companyName: string
   /* Resolves when the RAG namespace is seeded. The demo URL is already live and
    * correctly branded before this settles, but the widget can't answer anything
    * company-specific until it does. `POST /demos` ignores it (logging failures);
    * the queue worker awaits it before emailing the prospect. */
   crawlDone: Promise<void>
 }
+
+/* The prospect no longer supplies a company name up front, so one is inferred
+ * once the crawl has run — preferring the highest-quality signal available:
+ * the content-analysis LLM call (instructed to extract the exact business
+ * name off the site), then the brand probe's og:site_name/<title> read, then
+ * the domain itself as a last resort. A caller-supplied companyName (e.g. a
+ * direct POST /demos request) always wins, same as logoUrl/title overrides. */
+const resolveCompanyName = (
+  input: PreparedInput,
+  analysis: ContentAnalysis,
+  brand: BrandProbe
+): string =>
+  input.companyName?.trim() ||
+  analysis.businessName?.trim() ||
+  brand.title?.trim() ||
+  titleCaseFromHostname(input.companyWebsite)
 
 /* Orchestrates the full demo-setup flow. Everything up to and including the S3
  * upload runs inline so the caller gets a working demo URL back. The deep crawl
@@ -70,18 +96,21 @@ export const runPipeline = async (
     rawBrand
   )
 
-  const systemPrompt = buildSystemPrompt(input, analysis)
+  const companyName = resolveCompanyName(input, analysis, scraped.brand)
+  const resolvedInput = { ...input, companyName }
+
+  const systemPrompt = buildSystemPrompt(resolvedInput, analysis)
 
   // Persist config and upload the demo page in parallel.
-  const html = buildHtml(input, analysis, brand)
+  const html = buildHtml(resolvedInput, analysis, brand)
   const [, demoUrl] = await Promise.all([
-    persistCompanyConfig(input, systemPrompt),
+    persistCompanyConfig(resolvedInput, systemPrompt),
     uploadDemo(input.companyId, html)
   ])
 
   // Seed the RAG namespace. Started here, awaited (or not) by the caller.
-  const crawlDone = runCrawl(input)
+  const crawlDone = runCrawl(resolvedInput)
 
   logger.info(`Demo setup complete for ${input.companyId}: ${demoUrl}`)
-  return { demoUrl, crawlDone }
+  return { demoUrl, companyName, crawlDone }
 }

--- a/apps/demo-setup/src/queue/repo.ts
+++ b/apps/demo-setup/src/queue/repo.ts
@@ -63,6 +63,13 @@ export const setCompanyId = (id: string, companyId: string): Promise<void> =>
 export const setDemoUrl = (id: string, demoUrl: string): Promise<void> =>
   update(id, { demo_url: demoUrl })
 
+/* Written back once the pipeline infers a name (the marketing site no longer
+ * collects one), so the row stays a useful record even though it arrived null. */
+export const setCompanyName = (
+  id: string,
+  companyName: string
+): Promise<void> => update(id, { company_name: companyName })
+
 export const markComplete = (id: string): Promise<void> =>
   update(id, { status: 'complete', completed_at: new Date().toISOString() })
 

--- a/apps/demo-setup/src/queue/worker.ts
+++ b/apps/demo-setup/src/queue/worker.ts
@@ -3,7 +3,11 @@ import { env } from '../config/env'
 import { logger } from '../lib/logger'
 import { deriveCompanyId } from '../lib/slug'
 import { killActiveCrawls } from '../integrations/crawler'
-import { sendDemoPendingEmail, sendDemoReadyEmail, sendInternalAlert } from '../integrations/sendgrid'
+import {
+  sendDemoPendingEmail,
+  sendDemoReadyEmail,
+  sendInternalAlert
+} from '../integrations/sendgrid'
 import { runPipeline } from '../pipeline/run-pipeline'
 import {
   claimPending,
@@ -12,6 +16,7 @@ import {
   reapStale,
   releaseClaims,
   setCompanyId,
+  setCompanyName,
   setDemoUrl
 } from './repo'
 import type { DemoRequestRow } from '../types'
@@ -33,34 +38,44 @@ const errorMessage = (error: unknown): string =>
 
 const processRequest = async (row: DemoRequestRow): Promise<void> => {
   // Reuse the id from a previous attempt; a fresh slug would orphan that
-  // attempt's S3 objects and Upstash namespace.
-  const companyId = row.company_id ?? deriveCompanyId(row.company_name)
+  // attempt's S3 objects and Upstash namespace. Derived from the URL, not the
+  // company name — the prospect no longer supplies one, and the slug is
+  // needed immediately, before the pipeline has scraped anything.
+  const companyId = row.company_id ?? deriveCompanyId(row.website_url)
   if (!row.company_id) await setCompanyId(row.id, companyId)
 
   // Best-effort: a prospect not getting this receipt is far less costly than
   // stalling the actual build over a SendGrid hiccup, so don't await-and-fail
   // the request over it.
   void sendDemoPendingEmail({
-    to: row.delivery_email,
+    to: row.email,
     companyId,
-    companyName: row.company_name
+    websiteUrl: row.website_url
   })
 
-  const { demoUrl, crawlDone } = await runPipeline({
+  const { demoUrl, companyName, crawlDone } = await runPipeline({
     companyId,
-    companyName: row.company_name,
+    companyName: row.company_name ?? undefined,
     companyWebsite: row.website_url,
-    companyEmail: row.contact_email,
+    companyEmail: row.email,
     isProd: row.is_prod
   })
-  await setDemoUrl(row.id, demoUrl)
+  await Promise.all([
+    setDemoUrl(row.id, demoUrl),
+    setCompanyName(row.id, companyName)
+  ])
 
   // The demo is live and branded now, but its RAG namespace is empty until the
   // crawl lands. Emailing before this resolves sends the prospect to a chatbot
   // that can't answer anything about them.
   await crawlDone
 
-  const sent = await sendDemoReadyEmail({ to: row.delivery_email, companyId, demoUrl })
+  const sent = await sendDemoReadyEmail({
+    to: row.email,
+    companyId,
+    demoUrl,
+    companyName
+  })
   await markComplete(row.id)
 
   if (!sent) {
@@ -68,7 +83,7 @@ const processRequest = async (row: DemoRequestRow): Promise<void> => {
     // nothing. Flag it so a human can forward the link.
     logger.error(`Demo ${companyId} built but the email failed to send`)
     await sendInternalAlert({
-      subject: `[demo-setup] Built ${companyId} but could not email ${row.delivery_email}`,
+      subject: `[demo-setup] Built ${companyId} but could not email ${row.email}`,
       body: `The demo is live at ${demoUrl} but SendGrid rejected the notification. Forward it manually.`
     })
   }
@@ -101,9 +116,9 @@ const handleFailure = async (row: DemoRequestRow, error: unknown) => {
     await sendInternalAlert({
       subject: `[demo-setup] Demo request failed after ${row.max_attempts} attempts`,
       body: [
-        `Company: ${row.company_name}`,
+        `Company: ${row.company_name ?? '(not yet known)'}`,
         `Website: ${row.website_url}`,
-        `Delivery email: ${row.delivery_email}`,
+        `Email: ${row.email}`,
         `Request id: ${row.id}`,
         '',
         `Last error: ${message}`
@@ -140,7 +155,9 @@ const tick = async (): Promise<void> => {
 
   for (const row of rows) {
     inFlight.add(row.id)
-    logger.info(`Claimed demo request ${row.id} for ${row.company_name}`)
+    logger.info(
+      `Claimed demo request ${row.id} for ${row.company_name ?? row.website_url}`
+    )
 
     // Not awaited: the loop must stay free to fill the other concurrency slots.
     // Nothing may escape this IIFE — an unhandled rejection would kill the
@@ -176,7 +193,8 @@ export const startWorker = (): void => {
   // (analyze-content, detect-brand) — those aren't individually bounded by a
   // timeout, so budget a fixed allowance for them rather than ignoring them.
   const LLM_CALL_BUDGET_MS = 5 * 60 * 1000
-  const worstCaseMs = env.scrapeTimeoutMs + env.crawlTimeoutMs + LLM_CALL_BUDGET_MS
+  const worstCaseMs =
+    env.scrapeTimeoutMs + env.crawlTimeoutMs + LLM_CALL_BUDGET_MS
   if (env.queueStaleMinutes * 60_000 <= worstCaseMs) {
     throw new Error(
       `DEMO_STALE_MINUTES (${env.queueStaleMinutes}m) must exceed SCRAPE_TIMEOUT_MS + CRAWL_TIMEOUT_MS + ` +

--- a/apps/demo-setup/src/types.ts
+++ b/apps/demo-setup/src/types.ts
@@ -20,7 +20,9 @@ export const demoInputSchema = z.object({
     .string()
     .min(1)
     .regex(/^[a-zA-Z0-9_-]+$/, 'companyId must be alphanumeric, - or _ only'),
-  companyName: z.string().min(1),
+  // Optional: inferred from the crawl (business-name extraction, then the
+  // site's own branding/title, then the domain) when omitted.
+  companyName: z.string().min(1).optional(),
   companyWebsite: z.string().min(1),
   companyEmail: z.string().email(),
   companyPhone: z.string().optional(),
@@ -105,9 +107,12 @@ export type BrandProbe = {
 export type DemoRequestRow = {
   id: string
   website_url: string
-  company_name: string
-  contact_email: string
-  delivery_email: string
+  // No longer collected by the marketing site's form — null until the worker
+  // derives it from the crawl and writes it back (see queue/worker.ts).
+  company_name: string | null
+  // One address for both roles: it becomes the demo's support_email and is
+  // where the "demo ready" link is sent (the form collects a single email).
+  email: string
   source_path: string | null
   user_agent: string | null
   company_id: string | null


### PR DESCRIPTION
## Context

The marketing demo form was simplified to collect only a **website URL** and **one email** (dropping the company-name field and the separate demo-delivery email). This PR reworks the `demo-setup` pipeline and the `demo_requests` queue schema so the backend no longer depends on inputs the form no longer sends.

Companion PR in `Untap-website` collapses the form's email fields to match.

## Changes

**Company name is now derived, not supplied**
- `companyId` (S3 key prefix / Upstash namespace / demo URL slug) now derives from the website **hostname** instead of the company name — it's needed on claim, before anything is scraped (`lib/slug.ts`).
- The company name is resolved **mid-pipeline** from data already extracted for free, via a fallback chain: content-analysis `businessName` → brand-probe `title` (og:site_name/`<title>`) → title-cased hostname. A caller-supplied `companyName` (direct `POST /demos`) still wins, like the other optional overrides (`run-pipeline.ts`).
- The resolved name is written back onto the `demo_requests` row (`queue/repo.ts`, `worker.ts`).

**Emails**
- Pending email (sent on claim, pre-scrape) now references the submitted **URL** instead of a name.
- Ready email is **personalized** with the resolved company name.

**Schema — two migrations (already applied to prod)**
- `20260709000000` — `company_name` → nullable.
- `20260709010000` — collapse `contact_email` + `delivery_email` into a single `email` column (drops the redundant column, its index/format-check; adds `idx_demo_requests_email`; renames the format constraint).

## Deploy ordering

The schema migrations are **already applied to prod**. The `email`-column rename is breaking, so the companion `Untap-website` PR (which writes `email`) and this worker deploy (which reads `email`) should go out on top of the already-migrated schema — which is the current state.

## Verification

- `tsc --noEmit` clean in `apps/demo-setup`; eslint clean on touched files.
- Prod schema verified post-migration: `email` NOT NULL, `delivery_email` gone, `company_name` nullable, index + constraint present, migration history in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)