### PR TITLE
fix(demo-setup): fix dropped logo fallback, add Google Fonts loading

### DIFF
--- a/apps/demo-setup/src/pipeline/build-html.ts
+++ b/apps/demo-setup/src/pipeline/build-html.ts
@@ -69,13 +69,23 @@ const escapeForInlineScript = (json: string): string =>
     .split(PARAGRAPH_SEPARATOR)
     .join('\\u2029')
 
-const renderHtml = (config: WidgetConfig): string =>
+// fontLinkHref is built by google-fonts.ts via encodeURIComponent, so it's
+// already safe to embed directly in an href attribute.
+const renderFontLinks = (fontLinkHref: string | null): string =>
+  fontLinkHref
+    ? `
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet" href="${fontLinkHref}" />`
+    : ''
+
+const renderHtml = (config: WidgetConfig, fontLinkHref: string | null): string =>
   `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Dialogue Foundry Chat Playground</title>
+  <title>Dialogue Foundry Chat Playground</title>${renderFontLinks(fontLinkHref)}
   <script id="dialogue-foundry-config" type="application/json">
 ${escapeForInlineScript(JSON.stringify(config, undefined, 2))}
   </script>
@@ -94,4 +104,4 @@ export const buildHtml = (
   input: PreparedInput,
   analysis: ContentAnalysis,
   brand: BrandResult
-): string => renderHtml(buildConfig(input, analysis, brand))
+): string => renderHtml(buildConfig(input, analysis, brand), brand.fontLinkHref)

--- a/apps/demo-setup/src/pipeline/detect-brand.ts
+++ b/apps/demo-setup/src/pipeline/detect-brand.ts
@@ -166,8 +166,8 @@ const matchLogoByPosition = (
   box: BrandSelection['logoBox'],
   screenshotWidth: number,
   screenshotHeight: number
-): string => {
-  if (!box.found || !screenshotWidth || !screenshotHeight) return ''
+): string | null => {
+  if (!box.found || !screenshotWidth || !screenshotHeight) return null
   const target: PixelRect = {
     left: (box.xPct / 100) * screenshotWidth,
     top: (box.yPct / 100) * screenshotHeight,
@@ -181,7 +181,7 @@ const matchLogoByPosition = (
     const iou = intersectionOverUnion(target, logo.rect)
     if (iou > 0.05 && (!best || iou > best.iou)) best = { url: logo.url, iou }
   }
-  return best?.url ?? ''
+  return best?.url ?? null
 }
 
 /* Picks which widget header style the logo actually looks good on. Compares
@@ -247,6 +247,7 @@ export const detectBrand = async (
       brandColor: supplied.brandColor,
       secondaryColor: supplied.secondaryColor ?? '',
       fontFamily: font,
+      fontLinkHref: null,
       theme: await pickTheme(supplied.logoUrl, supplied.brandColor, input.companyId)
     }
   }
@@ -284,6 +285,7 @@ export const detectBrand = async (
       brandColor,
       secondaryColor,
       fontFamily: font,
+      fontLinkHref: null,
       theme: await pickTheme(logoUrl, brandColor, input.companyId)
     }
   }
@@ -352,6 +354,7 @@ export const detectBrand = async (
     brandColor,
     secondaryColor,
     fontFamily: font,
+    fontLinkHref: null,
     theme: await pickTheme(logoUrl, brandColor, input.companyId)
   }
 }

--- a/apps/demo-setup/src/pipeline/google-fonts.ts
+++ b/apps/demo-setup/src/pipeline/google-fonts.ts
@@ -1,0 +1,39 @@
+import { logger } from '../lib/logger'
+
+/* Google Fonts serves modern woff2 @font-face rules only to a browser-like
+ * User-Agent; without one it falls back to old formats we don't want. An
+ * unknown family still returns 200 with an empty stylesheet rather than a
+ * 404, so "does the response actually contain a @font-face rule" is the only
+ * reliable signal that the family exists in Google's catalog. */
+const MODERN_UA =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36'
+
+const FETCH_TIMEOUT_MS = 5000
+
+/* Resolves the primary font in a CSS font-family stack to a loadable Google
+ * Fonts stylesheet URL, or null if it isn't (or can't be confirmed to be) a
+ * real Google Fonts family. Queries Google directly rather than maintaining a
+ * static catalog — their catalog changes over time and a stale local list
+ * would silently stop matching new/renamed families. */
+export const resolveGoogleFontLink = async (fontFamily: string): Promise<string | null> => {
+  const primary = fontFamily.split(',')[0]?.trim().replace(/^["']|["']$/g, '')
+  if (!primary) return null
+
+  const href = `https://fonts.googleapis.com/css2?family=${encodeURIComponent(primary)}:wght@400;500;600;700&display=swap`
+
+  try {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+    const response = await fetch(href, {
+      headers: { 'User-Agent': MODERN_UA },
+      signal: controller.signal
+    }).finally(() => clearTimeout(timeout))
+
+    if (!response.ok) return null
+    const css = await response.text()
+    return css.includes('@font-face') ? href : null
+  } catch (error) {
+    logger.warn(`[fonts] Google Fonts lookup failed for "${primary}": ${error}`)
+    return null
+  }
+}

--- a/apps/demo-setup/src/pipeline/quality.ts
+++ b/apps/demo-setup/src/pipeline/quality.ts
@@ -1,5 +1,6 @@
 import { contrastRatio, parseRgb, toHex, type Rgb } from '../lib/color'
 import { logger } from '../lib/logger'
+import { resolveGoogleFontLink } from './google-fonts'
 import type { BrandResult, ContentAnalysis, Suggestion } from '../types'
 
 const isValidHttpUrl = (value: string): boolean => {
@@ -16,6 +17,28 @@ const isValidCssColor = (value: string): boolean =>
 
 const DEFAULT_BRAND_COLOR = '#1d4ed8'
 const DEFAULT_FONT_FAMILY = 'system-ui, sans-serif'
+
+/* Fonts guaranteed to render without loading anything — either OS-bundled
+ * fonts present across Windows/macOS/Linux, or CSS generic families the
+ * browser always resolves. A detected font outside this set (e.g. "Rubik")
+ * rendered fine in our headless probe because it loaded the source site's own
+ * font links — it won't render on the demo page unless we load it too, which
+ * is what the Google Fonts lookup below attempts before giving up on it. */
+const SAFE_FONT_NAMES = new Set([
+  'system-ui', '-apple-system', 'blinkmacsystemfont', 'segoe ui', 'ui-sans-serif', 'ui-serif', 'ui-monospace',
+  'arial', 'helvetica', 'helvetica neue', 'georgia', 'times new roman', 'times', 'verdana', 'tahoma',
+  'trebuchet ms', 'courier new', 'courier', 'garamond', 'palatino', 'palatino linotype',
+  'sans-serif', 'serif', 'monospace', 'cursive', 'fantasy'
+])
+
+/* True if at least one font in the stack is one we can guarantee renders —
+ * a detected font paired with its own generic fallback (e.g. "Rubik, sans-serif")
+ * is fine as-is; a bare unrecognized name (e.g. just "Rubik") is not. */
+const hasSafeFallback = (fontFamily: string): boolean =>
+  fontFamily
+    .split(',')
+    .map(part => part.trim().replace(/^["']|["']$/g, '').toLowerCase())
+    .some(name => SAFE_FONT_NAMES.has(name))
 
 /* The widget paints white text on primaryColor (--df-color-primary). WCAG AA for
  * large text / UI components is 3:1; below that the send button is unreadable. */
@@ -75,11 +98,11 @@ const FALLBACK_SUGGESTION: Suggestion = {
  * anything that fails so a bad LLM output never ships a broken widget (empty
  * welcome message, malformed color, garbage logo URL). Logs every repair so
  * regressions are visible without failing the whole request. */
-export const enforceQuality = (
+export const enforceQuality = async (
   companyId: string,
   analysis: ContentAnalysis,
   brand: BrandResult
-): { analysis: ContentAnalysis; brand: BrandResult } => {
+): Promise<{ analysis: ContentAnalysis; brand: BrandResult }> => {
   const safeAnalysis = { ...analysis }
   const safeBrand = { ...brand }
 
@@ -141,7 +164,21 @@ export const enforceQuality = (
     safeBrand.secondaryColor = lightened
   }
 
-  if (!safeBrand.fontFamily) {
+  if (safeBrand.fontFamily && !hasSafeFallback(safeBrand.fontFamily)) {
+    const fontLinkHref = await resolveGoogleFontLink(safeBrand.fontFamily)
+    if (fontLinkHref) {
+      logger.info(`[quality ${companyId}] loading "${safeBrand.fontFamily}" from Google Fonts`)
+      safeBrand.fontLinkHref = fontLinkHref
+      // Keep a generic fallback in the CSS value itself so a slow/failed font
+      // load still degrades gracefully instead of falling to the browser default.
+      safeBrand.fontFamily = `${safeBrand.fontFamily}, sans-serif`
+    } else {
+      logger.warn(
+        `[quality ${companyId}] fontFamily "${safeBrand.fontFamily}" has no safe fallback and isn't a Google Font, using default`
+      )
+      safeBrand.fontFamily = DEFAULT_FONT_FAMILY
+    }
+  } else if (!safeBrand.fontFamily) {
     safeBrand.fontFamily = DEFAULT_FONT_FAMILY
   }
 

--- a/apps/demo-setup/src/pipeline/run-pipeline.ts
+++ b/apps/demo-setup/src/pipeline/run-pipeline.ts
@@ -90,7 +90,7 @@ export const runPipeline = async (
     )
   ])
 
-  const { analysis, brand } = enforceQuality(
+  const { analysis, brand } = await enforceQuality(
     input.companyId,
     rawAnalysis,
     rawBrand

--- a/apps/demo-setup/src/types.ts
+++ b/apps/demo-setup/src/types.ts
@@ -72,6 +72,10 @@ export type BrandResult = {
   secondaryColor: string
   fontFamily: string
   theme: 'primary' | 'secondary'
+  // Set by quality.ts when fontFamily is a confirmed-loadable Google Fonts
+  // family; null when it's a system-safe name or wasn't found in Google's
+  // catalog (fontFamily falls back to the default stack in that case).
+  fontLinkHref: string | null
 }
 
 export type PixelRect = { top: number; left: number; width: number; height: number }


### PR DESCRIPTION
## Summary
- Fixed a `??` vs `''` bug in `matchLogoByPosition` (`detect-brand.ts`) that silently discarded good DOM logo candidates whenever the vision-based logo match failed — this is why Bend Brewing Co's demo shipped with no logo despite 4 valid candidates being found.
- Added real Google Fonts loading (`pipeline/google-fonts.ts`): when the detected brand font (e.g. "Rubik") isn't a system-safe font, we now query Google's CSS API and, if it resolves, inject an actual `<link>` stylesheet into the generated demo page. If it's not a Google Font, we fall back to the default font stack instead of referencing an unloadable name.

## Root cause
Bend Brewing Co's demo (`demo-bendbrewingco-d786e93b`) had `logoUrl: ""` and `fontFamily: "Rubik"` with no way to actually load Rubik. Traced to:
1. `matchLogoByPosition` returned `''` instead of `null` on no-match, which broke the `positionMatchedLogo ?? finalLogoPool[0]` fallback chain (`??` only falls through on `null`/`undefined`, not `''`).
2. The pipeline detected the site's real font via computed styles but never attempted to load it on the demo page — it only rendered correctly in the scraping probe because that probe loaded the source site's own font `<link>` tags.

## Changes
- `detect-brand.ts` — `matchLogoByPosition` now returns `string | null`, fixing the fallback chain.
- `pipeline/google-fonts.ts` (new) — resolves a font name against Google Fonts' CSS2 API (verified live: known fonts return 200 + `@font-face`, unknown fonts 400).
- `pipeline/quality.ts` — async now; tries Google Fonts before falling back to `system-ui, sans-serif`.
- `pipeline/build-html.ts` — injects `<link rel="preconnect">`/`<link rel="stylesheet">` for the resolved font.
- `pipeline/run-pipeline.ts` — awaits the now-async `enforceQuality`.
- `types.ts` — added `fontLinkHref: string | null` to `BrandResult`.

## Test plan
- [x] `tsc --noEmit` / `pnpm run build` pass clean
- [x] Live smoke test against Google Fonts API confirms resolution logic (Rubik resolves, bogus names 400)
- [ ] Re-run the demo-setup pipeline against bendbrewingco.com and confirm logo + Rubik font both render on the published demo page

🤖 Generated with [Claude Code](https://claude.com/claude-code)