### PR TITLE
fix(demo-setup): force unbuffered Python output for the crawl subprocess

### DIFF
--- a/apps/demo-setup/src/integrations/crawler.ts
+++ b/apps/demo-setup/src/integrations/crawler.ts
@@ -34,6 +34,11 @@ export const runCrawl = (input: PreparedInput): Promise<void> =>
       detached: true,
       env: {
         ...process.env,
+        // Belt-and-suspenders alongside orchestrator.py's own
+        // sys.stdout.reconfigure(line_buffering=True) — a piped stdout is
+        // block-buffered by default and can hide many minutes of crawl
+        // progress from these logs.
+        PYTHONUNBUFFERED: '1',
         START_URLS: input.companyWebsite,
         MAX_DEPTH: env.crawlerMaxDepth(input.isProd),
         MAX_PAGES: env.crawlerMaxPages,


### PR DESCRIPTION
## Summary
While debugging why apple.com's demo crawl was taking 30+ min, its logs showed a 20+ minute stretch with zero output — turned out to be Python's default block-buffered stdout when piped (not a TTY), hiding real crawl progress rather than indicating a hang.

Sets `PYTHONUNBUFFERED=1` when spawning the crawler subprocess. Pairs with a matching `sys.stdout.reconfigure(line_buffering=True)` fix in web-crawler's `orchestrator.py` ([web-crawler#18](https://github.com/Untap-AI/web-crawler/pull/18)).

## Test plan
- [x] `tsc --noEmit` passes clean
- [ ] Re-run a demo-setup crawl and confirm incremental progress now appears in pm2 logs in near-real-time instead of in one buffered dump

🤖 Generated with [Claude Code](https://claude.com/claude-code)