### PR TITLE
fix(demo-setup): don't resend the pending email on reclaimed attempts

### DIFF
--- a/apps/demo-setup/src/queue/worker.ts
+++ b/apps/demo-setup/src/queue/worker.ts
@@ -44,14 +44,19 @@ const processRequest = async (row: DemoRequestRow): Promise<void> => {
   const companyId = row.company_id ?? deriveCompanyId(row.website_url)
   if (!row.company_id) await setCompanyId(row.id, companyId)
 
-  // Best-effort: a prospect not getting this receipt is far less costly than
-  // stalling the actual build over a SendGrid hiccup, so don't await-and-fail
-  // the request over it.
-  void sendDemoPendingEmail({
-    to: row.email,
-    companyId,
-    websiteUrl: row.website_url
-  })
+  // Only on the row's first-ever claim — claim_demo_requests increments
+  // attempts on every claim, including reclaims after a restart or stale
+  // timeout, so attempts > 1 here means the prospect already got this email
+  // for this request. Best-effort: a prospect not getting the receipt is far
+  // less costly than stalling the actual build over a SendGrid hiccup, so
+  // don't await-and-fail the request over it.
+  if (row.attempts === 1) {
+    void sendDemoPendingEmail({
+      to: row.email,
+      companyId,
+      websiteUrl: row.website_url
+    })
+  }
 
   const { demoUrl, companyName, crawlDone } = await runPipeline({
     companyId,


### PR DESCRIPTION
## Summary
`processRequest` (`apps/demo-setup/src/queue/worker.ts`) sent the "Your demo is being created" email unconditionally on every claim of a `demo_requests` row — including reclaims after a worker restart or a stale-claim timeout. This surfaced clearly while debugging apple.com's crawl-timeout retries: each retry sent the prospect a duplicate pending email.

`claim_demo_requests` (see migration `20260708000000_add_demo_requests_table.sql`) increments `attempts` on every claim, first or not — so `row.attempts === 1` reliably identifies a row's first-ever claim. Gates the send on that instead.

## Test plan
- [x] `tsc --noEmit` passes clean
- [ ] Restart the worker mid-crawl on a real request and confirm only the very first claim sends the pending email; reclaimed attempts stay silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)