### PR TITLE
feat(demo-setup): pick the logo by vision over rendered candidate images

### DIFF
--- a/apps/demo-setup/src/integrations/scraper.ts
+++ b/apps/demo-setup/src/integrations/scraper.ts
@@ -13,8 +13,8 @@ export type ScrapeResult = {
   brand: BrandProbe
   /* Base64 JPEG of the homepage above the fold, or '' if capture failed. */
   screenshot: string
-  // Pixel dimensions of `screenshot` — needed to convert the vision model's
-  // percentage-based logo bounding box back into page pixel coordinates.
+  // Pixel dimensions of `screenshot`, as reported by scrape_page.py. No longer
+  // consumed since logo selection moved off bounding-box coordinate matching.
   screenshotWidth: number
   screenshotHeight: number
 }

--- a/apps/demo-setup/src/pipeline/detect-brand.ts
+++ b/apps/demo-setup/src/pipeline/detect-brand.ts
@@ -3,60 +3,44 @@ import { generateObject, jsonSchema } from 'ai'
 import { contrastFromLuminances, luminance, parseRgb } from '../lib/color'
 import { env } from '../config/env'
 import { logger } from '../lib/logger'
+import { rasterizeLogoCandidate } from './rasterize-logo'
 import { estimateLogoInkLuminance, sampleLogoColor } from './sample-logo-color'
 import type { BrandCandidates } from './extract-brand-candidates'
-import type { BrandProbe, BrandResult, PixelRect, PreparedInput } from '../types'
+import type { BrandProbe, BrandResult, PreparedInput } from '../types'
 
 /* The model picks *indices* for colors, never invents a hex — "#7A2C3D" for a
  * site whose actual brand is "#7B2D3E" looks right in a chat reply and wrong
  * next to the real site. Every color it can return is a string we read out of
  * the live DOM or the rendered pixels.
  *
- * The logo is different: asking for an index into a text-described list is
- * exactly how the real horse-emblem logo on West Hills Vineyards got missed —
- * it wasn't a top candidate by any selector heuristic, so it was never index 0
- * or 1 in a list a model skims. A human designer just points at the picture.
- * So logoBox asks the model to do the same: locate the logo visually, as a
- * bounding box on the screenshot. We then match that box against whatever
- * concrete asset (image URL or inline SVG) sits in the same place — turning
- * vision into a spatial filter over real candidates, not a freeform picker. */
+ * The logo is picked the same way, but over *images*: each candidate the probe
+ * collected is rasterized and attached to the vision call, and the model picks
+ * the one that is actually the company's logo by looking at it. Two prior
+ * designs both failed on real sites: index-into-a-text-list missed West Hills
+ * Vineyards' horse emblem (heuristic ranking never surfaced it), and
+ * locate-by-bounding-box shipped apple.com a "TV & Home" nav glyph (the box
+ * missed, and the coordinate match fell back to the heuristic top pick).
+ * Looking at the candidate pixels sidesteps both: no score decides, and no
+ * screenshot geometry has to line up. */
 type BrandSelection = {
   primaryIndex: number
-  logoBox: {
-    found: boolean
-    xPct: number
-    yPct: number
-    widthPct: number
-    heightPct: number
-  }
+  logoIndex: number
 }
 
 const selectionSchema = jsonSchema<BrandSelection>({
   type: 'object',
   additionalProperties: false,
-  required: ['primaryIndex', 'logoBox'],
+  required: ['primaryIndex', 'logoIndex'],
   properties: {
     primaryIndex: {
       type: 'integer',
       description:
         "Index of the color that visually dominates this brand's identity — the color used most prominently across the header, navigation, buttons, and accents in the screenshot. Think like a designer describing the brand's \"main color\": not necessarily the single largest area (a photo background doesn't count), but the flat brand color that recurs across UI elements. Never a white, off-white, black, or grey page background. When several candidates are near-identical shades of the same hue, prefer whichever one's note says it covers more of the rendered page — that measurement comes directly from the screenshot's pixels and can't be wrong the way a CSS variable name can (site builders like Wix often name variables generically, e.g. '--wst-color-custom-4', which tells you nothing about whether it's actually the primary color). Use -1 if none of the candidates match."
     },
-    logoBox: {
-      type: 'object',
-      additionalProperties: false,
-      required: ['found', 'xPct', 'yPct', 'widthPct', 'heightPct'],
+    logoIndex: {
+      type: 'integer',
       description:
-        "Locate the company's logo mark or wordmark as it visually appears in the screenshot — this may be a text wordmark in the header, OR a distinct pictorial mark/emblem/seal (e.g. an icon, crest, or illustration representing the brand), which is often the more recognizable 'logo' even if a text banner also appears elsewhere on the page. Prefer the pictorial mark over a plain text banner when both are present.",
-      properties: {
-        found: {
-          type: 'boolean',
-          description: 'true if a distinct logo mark or wordmark is visible anywhere in the screenshot'
-        },
-        xPct: { type: 'number', description: 'Left edge of the logo, as a percentage (0-100) of the screenshot width' },
-        yPct: { type: 'number', description: 'Top edge of the logo, as a percentage (0-100) of the screenshot height' },
-        widthPct: { type: 'number', description: 'Width of the logo, as a percentage (0-100) of the screenshot width' },
-        heightPct: { type: 'number', description: 'Height of the logo, as a percentage (0-100) of the screenshot height' }
-      }
+        "Index of the numbered candidate image that is this company's logo — the mark or wordmark that identifies the brand, usually shown in the site header and often wrapped in a link to the homepage. Judge each candidate by looking at its image: a navigation label, menu icon, product shot, social icon, or promo banner is NOT the logo even if it sits in the header. When both a pictorial mark/emblem and a plain text rendering are among the candidates, prefer the pictorial mark. Use -1 if none of the candidate images is the company's logo."
     }
   }
 })
@@ -135,53 +119,60 @@ const rankColors = (probe: BrandProbe, logoColors: string[]): ColorCandidate[] =
   return ranked.slice(0, 10)
 }
 
-/* A data: URI is a legitimate logo (we serialize inline <svg> wordmarks), but it
- * can be 20KB — far too long to put in a prompt. Show the model a stable stub
- * and map the index back to the real value afterwards. */
-const describeLogo = (url: string): string =>
-  url.startsWith('data:')
-    ? `${url.slice(0, 40)}… (inline SVG, ${url.length} chars)`
-    : url
-
 const pick = (list: ColorCandidate[], index: number): string =>
   Number.isInteger(index) && index >= 0 && index < list.length ? list[index].hex : ''
 
-const intersectionOverUnion = (a: PixelRect, b: PixelRect): number => {
-  const x1 = Math.max(a.left, b.left)
-  const y1 = Math.max(a.top, b.top)
-  const x2 = Math.min(a.left + a.width, b.left + b.width)
-  const y2 = Math.min(a.top + a.height, b.top + b.height)
-  const overlap = Math.max(0, x2 - x1) * Math.max(0, y2 - y1)
-  if (overlap <= 0) return 0
-  const union = a.width * a.height + b.width * b.height - overlap
-  return union > 0 ? overlap / union : 0
+type LogoCandidate = NonNullable<BrandProbe['logos']>[number]
+type VisionLogoCandidate = { logo: LogoCandidate; png: string }
+
+/* One line of DOM context per candidate image — where it sat and how it was
+ * labeled. The image itself does most of the work; this catches the case where
+ * two candidates look alike (a mark vs. its og:image rendition, say). */
+const describeCandidate = (logo: LogoCandidate): string => {
+  const parts: string[] = [logo.kind === 'svg' ? 'inline SVG' : logo.kind]
+  if (logo.rect) {
+    parts.push(
+      `${logo.rect.width}x${logo.rect.height}px at (${logo.rect.left}, ${logo.rect.top}) on the page`
+    )
+  }
+  if (logo.alt) parts.push(`labeled "${logo.alt}"`)
+  if (logo.anchorLabel) parts.push(`inside a link labeled "${logo.anchorLabel}"`)
+  if (logo.linksHome) parts.push('links to the homepage')
+  if (logo.recurringPages) parts.push(`recurs on ${logo.recurringPages} pages`)
+  return parts.join(', ')
 }
 
-/* The model localizes the logo visually; this resolves that location to a
- * concrete asset by finding whichever candidate's on-page position overlaps
- * it best. Lenient IoU threshold — the model's box is a rough visual estimate,
- * not a precise crop, so demanding tight overlap would reject good matches. */
-const matchLogoByPosition = (
-  logos: NonNullable<BrandProbe['logos']>,
-  box: BrandSelection['logoBox'],
-  screenshotWidth: number,
-  screenshotHeight: number
-): string | null => {
-  if (!box.found || !screenshotWidth || !screenshotHeight) return null
-  const target: PixelRect = {
-    left: (box.xPct / 100) * screenshotWidth,
-    top: (box.yPct / 100) * screenshotHeight,
-    width: (box.widthPct / 100) * screenshotWidth,
-    height: (box.heightPct / 100) * screenshotHeight
-  }
+/* Enough to always include the real mark (the probe's pre-rank only has to get
+ * it into the top 8, not to #1), small enough that the vision call stays cheap
+ * — the tiles are ≤256px. */
+const VISION_CANDIDATE_LIMIT = 8
 
-  let best: { url: string; iou: number } | null = null
-  for (const logo of logos) {
-    if (!logo.rect) continue
-    const iou = intersectionOverUnion(target, logo.rect)
-    if (iou > 0.05 && (!best || iou > best.iou)) best = { url: logo.url, iou }
-  }
-  return best?.url ?? null
+const rasterizeCandidates = async (
+  logos: LogoCandidate[]
+): Promise<VisionLogoCandidate[]> => {
+  const rendered = await Promise.all(
+    logos.slice(0, VISION_CANDIDATE_LIMIT).map(async logo => ({
+      logo,
+      png: await rasterizeLogoCandidate(logo.url)
+    }))
+  )
+  return rendered.filter((c): c is VisionLogoCandidate => c.png !== null)
+}
+
+/* When vision abstains or fails: a schema.org-declared logo is authoritative
+ * (score >= 100 keeps Organization.logo and excludes the weaker
+ * Organization.image entries that share the kind), an apple-touch-icon is
+ * at least always the brand's own mark, and only then the heuristic top pick
+ * — the ranking that shipped apple.com a nav glyph — gets a say. */
+const fallbackLogoUrl = (
+  logos: LogoCandidate[],
+  rankedUrls: string[]
+): string => {
+  const declared = logos.find(
+    logo => logo.kind === 'ld+json' && logo.score >= 100
+  )?.url
+  const touchIcon = logos.find(logo => logo.kind === 'apple-touch-icon')?.url
+  return declared ?? touchIcon ?? rankedUrls[0] ?? ''
 }
 
 /* Picks which widget header style the logo actually looks good on. Compares
@@ -214,18 +205,16 @@ const pickTheme = async (
 
 /* Selects the site's real brand signals. The probe gives us exact values from
  * the live DOM and rendered pixels; the vision call decides which of them the
- * brand actually leads with (colors) and where the logo visually sits (matched
- * back to a real asset by position). Falls back to the probe's own ranking
- * whenever the model abstains, and to the legacy HTML-regex candidates when
- * the probe couldn't run at all.
+ * brand actually leads with (colors) and which candidate image is the real
+ * logo (by looking at the candidates themselves). Falls back to declared
+ * logos / the probe's own ranking whenever the model abstains, and to the
+ * legacy HTML-regex candidates when the probe couldn't run at all.
  *
  * Caller-supplied values always win and skip the LLM. */
 export const detectBrand = async (
   input: PreparedInput,
   probe: BrandProbe,
   screenshot: string,
-  screenshotWidth: number,
-  screenshotHeight: number,
   fallback: BrandCandidates
 ): Promise<BrandResult> => {
   const supplied = {
@@ -290,16 +279,35 @@ export const detectBrand = async (
     }
   }
 
+  // Legacy HTML-regex fallback candidates are bare URLs; wrap them so they can
+  // ride the same rasterize-and-look path when the probe found nothing.
+  const visionSourceLogos: LogoCandidate[] = logos.length
+    ? logos
+    : fallback.logoCandidates.map(url => ({ url, kind: 'img', score: 0 }))
+  const logoCandidates = await rasterizeCandidates(visionSourceLogos)
+
+  if (logoCandidates.length) {
+    logger.info(
+      `[brand ${input.companyId}] logo candidates: ` +
+        logoCandidates
+          .map(
+            (candidate, index) =>
+              `#${index} ${describeCandidate(candidate.logo)} [score ${candidate.logo.score}] ${candidate.logo.url.slice(0, 100)}`
+          )
+          .join(' | ')
+    )
+  }
+
   const prompt = [
     `Website: ${input.companyWebsite}`,
     '',
     'Colors sampled from the live page (index: value — note):',
     ...finalColorPool.map((candidate, index) => `${index}: ${candidate.hex} — ${candidate.note}`),
     '',
-    'For reference, images found on the page that might be the logo (not used by index — locate the logo visually in the screenshot instead):',
-    ...finalLogoPool.map((url, index) => `${index}: ${describeLogo(url)}`),
-    '',
-    'The attached screenshot is the top of this homepage.'
+    'The first attached image is a screenshot of the top of this homepage, for context.',
+    logoCandidates.length
+      ? `After it come ${logoCandidates.length} numbered logo-candidate images, each an image actually found on the page, rendered on a neutral grey tile and captioned with where it sat and how it was labeled. Pick the candidate that is this company's logo.`
+      : 'No logo-candidate images could be rendered for this page; return -1 for logoIndex.'
   ].join('\n')
 
   let selection: BrandSelection
@@ -308,13 +316,24 @@ export const detectBrand = async (
       model: anthropic(env.modelBrand),
       schema: selectionSchema,
       system:
-        "You are a brand designer reviewing a website screenshot. Identify the brand's primary color from the given candidate list by index, and locate the company's logo visually in the image (as a bounding box), the way a designer would point at it — not by guessing which listed URL it corresponds to.",
+        "You are a brand designer reviewing a website. Identify the brand's primary color from the given candidate list by index, and identify the company's logo by looking at the numbered candidate images — judge each by what it actually depicts, the way a designer would.",
       messages: [
         {
           role: 'user',
           content: [
-            { type: 'text', text: prompt },
-            { type: 'image', image: screenshot, mediaType: 'image/jpeg' }
+            { type: 'text' as const, text: prompt },
+            { type: 'image' as const, image: screenshot, mediaType: 'image/jpeg' },
+            ...logoCandidates.flatMap((candidate, index) => [
+              {
+                type: 'text' as const,
+                text: `Logo candidate ${index}: ${describeCandidate(candidate.logo)}`
+              },
+              {
+                type: 'image' as const,
+                image: candidate.png,
+                mediaType: 'image/png'
+              }
+            ])
           ]
         }
       ]
@@ -322,30 +341,30 @@ export const detectBrand = async (
     selection = object
   } catch (error) {
     logger.warn(
-      `[brand ${input.companyId}] vision selection failed (${error}); using probe ranking`
+      `[brand ${input.companyId}] vision selection failed (${error}); using fallback ranking`
     )
-    selection = {
-      primaryIndex: 0,
-      logoBox: { found: false, xPct: 0, yPct: 0, widthPct: 0, heightPct: 0 }
-    }
+    selection = { primaryIndex: 0, logoIndex: -1 }
   }
 
   // -1 means "none of these" — fall back to the probe's own top pick rather than
   // shipping an empty color, which quality.ts would replace with a generic blue.
   const primary = pick(finalColorPool, selection.primaryIndex) || finalColorPool[0]?.hex || ''
 
-  const positionMatchedLogo = matchLogoByPosition(
-    logos,
-    selection.logoBox,
-    screenshotWidth,
-    screenshotHeight
-  )
-  const logoUrl = supplied.logoUrl ?? positionMatchedLogo ?? finalLogoPool[0] ?? ''
+  const visionPickedLogo =
+    Number.isInteger(selection.logoIndex) &&
+    selection.logoIndex >= 0 &&
+    selection.logoIndex < logoCandidates.length
+      ? logoCandidates[selection.logoIndex].logo.url
+      : null
+  const logoUrl =
+    supplied.logoUrl ??
+    visionPickedLogo ??
+    fallbackLogoUrl(logos, finalLogoPool)
 
   logger.info(
     `[brand ${input.companyId}] primary=${primary} ` +
-      `logo=${positionMatchedLogo ? 'position-matched' : logoUrl ? 'top-ranked fallback' : 'none'} ` +
-      `from ${finalColorPool.length} colors, ${finalLogoPool.length} logo candidates`
+      `logo=${visionPickedLogo ? `vision-picked #${selection.logoIndex}` : logoUrl ? 'fallback chain' : 'none'} ` +
+      `from ${finalColorPool.length} colors, ${logoCandidates.length}/${visionSourceLogos.length} logo candidates rendered`
   )
 
   const brandColor = supplied.brandColor ?? primary

--- a/apps/demo-setup/src/pipeline/rasterize-logo.ts
+++ b/apps/demo-setup/src/pipeline/rasterize-logo.ts
@@ -1,0 +1,35 @@
+import sharp from 'sharp'
+import { fetchImageBuffer } from './sample-logo-color'
+
+/* Renders a logo candidate to a small PNG the vision model can actually look
+ * at, so logo selection happens by inspecting the candidate images themselves
+ * rather than by heuristic score or screenshot-coordinate matching. */
+
+const MAX_EDGE = 256
+// sharp rasterizes SVGs at their intrinsic size (72 DPI) — a 14x44 mark would
+// come out too small for a vision model to judge. A higher density renders it
+// ~4x larger; raster inputs ignore this option.
+const SVG_DENSITY = 288
+// Flatten transparency onto light grey, not white: plenty of marks are drawn
+// as white ink for a colored header and would vanish on a white tile.
+const BACKGROUND = { r: 230, g: 230, b: 230 }
+
+export const rasterizeLogoCandidate = async (
+  url: string
+): Promise<string | null> => {
+  const buffer = await fetchImageBuffer(url)
+  if (!buffer) return null
+
+  try {
+    const rendered = await sharp(buffer, { density: SVG_DENSITY })
+      .resize(MAX_EDGE, MAX_EDGE, { fit: 'inside', withoutEnlargement: true })
+      .flatten({ background: BACKGROUND })
+      .png()
+      .toBuffer()
+    return rendered.toString('base64')
+  } catch {
+    // .ico favicons, corrupt images, unsupported formats — drop the candidate
+    // rather than failing brand detection over it.
+    return null
+  }
+}

--- a/apps/demo-setup/src/pipeline/run-pipeline.ts
+++ b/apps/demo-setup/src/pipeline/run-pipeline.ts
@@ -80,14 +80,7 @@ export const runPipeline = async (
   // The two consolidated LLM calls, run in parallel.
   const [rawAnalysis, rawBrand] = await Promise.all([
     analyzeContent(pages),
-    detectBrand(
-      input,
-      scraped.brand,
-      scraped.screenshot,
-      scraped.screenshotWidth,
-      scraped.screenshotHeight,
-      fallbackCandidates
-    )
+    detectBrand(input, scraped.brand, scraped.screenshot, fallbackCandidates)
   ])
 
   const { analysis, brand } = await enforceQuality(

--- a/apps/demo-setup/src/pipeline/sample-logo-color.ts
+++ b/apps/demo-setup/src/pipeline/sample-logo-color.ts
@@ -22,7 +22,7 @@ import { luminance } from '../lib/color'
 const SAMPLE_SIZE = 128
 const FETCH_TIMEOUT_MS = 5000
 
-const toBuffer = async (url: string): Promise<Buffer | null> => {
+export const fetchImageBuffer = async (url: string): Promise<Buffer | null> => {
   if (url.startsWith('data:')) {
     const base64 = url.split(',')[1]
     return base64 ? Buffer.from(base64, 'base64') : null
@@ -39,7 +39,7 @@ const toBuffer = async (url: string): Promise<Buffer | null> => {
 }
 
 export const sampleLogoColor = async (url: string): Promise<string | null> => {
-  const buffer = await toBuffer(url)
+  const buffer = await fetchImageBuffer(url)
   if (!buffer) return null
 
   try {
@@ -82,7 +82,7 @@ export const sampleLogoColor = async (url: string): Promise<string | null> => {
  * what it's normally shown against?" Used to decide whether a colored
  * (primaryColor) or white header background gives the logo better contrast. */
 export const estimateLogoInkLuminance = async (url: string): Promise<number | null> => {
-  const buffer = await toBuffer(url)
+  const buffer = await fetchImageBuffer(url)
   if (!buffer) return null
 
   try {

--- a/apps/demo-setup/src/types.ts
+++ b/apps/demo-setup/src/types.ts
@@ -93,7 +93,9 @@ export type BrandProbe = {
   fonts?: { body?: string | null; heading?: string | null }
   // `rect` is present for candidates found on the homepage (brand_probe.js);
   // recurrence-only candidates folded in from other pages (scrape_page.py's
-  // _apply_logo_recurrence) have no single position and omit it.
+  // _apply_logo_recurrence) have no single position and omit those fields.
+  // alt/anchorLabel/linksHome are shown to the vision model as per-candidate
+  // context when it picks the logo by looking at the candidate images.
   logos?: {
     url: string
     kind: string
@@ -101,6 +103,9 @@ export type BrandProbe = {
     score: number
     rect?: PixelRect
     recurringPages?: number
+    alt?: string | null
+    anchorLabel?: string | null
+    linksHome?: boolean
   }[]
   title?: string | null
 }


### PR DESCRIPTION
## Why

apple.com's demo shipped a **"TV & Home" nav glyph** as its logo. The bounding-box + IoU-matching design failed (tiny navbar mark; one run's screenshot was covered by an app-store modal), and the fallback — the probe's hand-tuned heuristic score — picked a nav label. Score-based selection is overfit by construction: every constant was tuned reactively to one site (West Hills, Pizzeria Bianco, now Apple).

## What

Selection now happens by **looking at the candidates**, in the same single vision call that picks the brand color:

- New `rasterize-logo.ts`: renders each candidate to a ≤256px PNG (sharp) — flattened onto light grey so white-ink marks stay visible, SVGs rasterized at high density so a 14×44 mark is legible.
- `detect-brand.ts`: candidates are attached as numbered images, each captioned with one line of DOM context from the probe (`alt`, wrapping anchor label, links-home, recurrence). The model returns `logoIndex`; `logoBox`/IoU matching is deleted.
- Fallback when vision abstains or errors: schema.org-declared logo → apple-touch-icon → heuristic top pick.
- The full candidate list is logged per run, so the next misfire is diagnosable from logs alone.

Companion web-crawler PR fixes collection (the real Apple mark was dropped by a size floor before selection ever saw it) and adds the context fields.

## Verification

- `tsc --noEmit` + build clean.
- Replayed a live apple.com scrape through the new `detectBrand` with a real vision call: picked the **real 14×44 Apple mark (#3)** over seven nav-glyph decoys that all outscored it heuristically ("TV & Home" was still #0 at score 320). Color selection unaffected (`#0066cc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)