### PR TITLE
feat(demo-setup): show vision the structured-data logo candidates, and trim padding

### DIFF
--- a/apps/demo-setup/src/pipeline/detect-brand.ts
+++ b/apps/demo-setup/src/pipeline/detect-brand.ts
@@ -3,7 +3,7 @@ import { generateObject, jsonSchema } from 'ai'
 import { contrastFromLuminances, luminance, parseRgb } from '../lib/color'
 import { env } from '../config/env'
 import { logger } from '../lib/logger'
-import { rasterizeLogoCandidate } from './rasterize-logo'
+import { rasterizeLogoCandidate, trimLogoForDisplay } from './rasterize-logo'
 import { estimateLogoInkLuminance, sampleLogoColor } from './sample-logo-color'
 import type { BrandCandidates } from './extract-brand-candidates'
 import type { BrandProbe, BrandResult, PreparedInput } from '../types'
@@ -40,7 +40,7 @@ const selectionSchema = jsonSchema<BrandSelection>({
     logoIndex: {
       type: 'integer',
       description:
-        "Index of the numbered candidate image that is this company's logo — the mark or wordmark that identifies the brand, usually shown in the site header and often wrapped in a link to the homepage. Judge each candidate by looking at its image: a navigation label, menu icon, product shot, social icon, or promo banner is NOT the logo even if it sits in the header. When both a pictorial mark/emblem and a plain text rendering are among the candidates, prefer the pictorial mark. Use -1 if none of the candidate images is the company's logo."
+        "Index of the numbered candidate image that is this company's logo — the mark or wordmark that identifies the brand. Judge each candidate by LOOKING at its image, not by its stated provenance. A navigation label (e.g. a glyph spelling 'TV & Home' or 'Store'), menu icon, product shot, social icon, headshot, or promo banner is NOT the logo, even if it sits in the header. A candidate described as a social-preview (og:image/twitter:image) is often a marketing or hero photo rather than a logo — but when it shows the bare brand mark on a plain background it is usually the cleanest version of the logo available, so prefer it over a tiny header glyph. A candidate declared by the site as its schema.org logo is the strongest prior; still reject it if the image plainly isn't a logo. Prefer an image containing the brand's mark and/or name over a generic icon. Use -1 if none of the candidate images is the company's logo."
     }
   }
 })
@@ -125,11 +125,27 @@ const pick = (list: ColorCandidate[], index: number): string =>
 type LogoCandidate = NonNullable<BrandProbe['logos']>[number]
 type VisionLogoCandidate = { logo: LogoCandidate; png: string }
 
-/* One line of DOM context per candidate image — where it sat and how it was
- * labeled. The image itself does most of the work; this catches the case where
- * two candidates look alike (a mark vs. its og:image rendition, say). */
+/* How each candidate got here, in the model's terms. A publisher-declared logo
+ * is a far stronger prior than "an image we found in the header", but not a
+ * certainty — og:image is frequently a marketing/hero shot — so the provenance
+ * is stated and the model still judges by looking. */
+const PROVENANCE: Record<string, string> = {
+  'ld+json': 'declared by the site as its logo (schema.org Organization.logo)',
+  og: "the site's og:image social-preview image",
+  twitter: "the site's twitter:image social-preview image",
+  tile: "the site's Windows tile image",
+  manifest: "an icon from the site's web app manifest",
+  'apple-touch-icon': "the site's apple-touch-icon",
+  favicon: "the site's favicon",
+  img: 'an image found on the page',
+  svg: 'an inline SVG found on the page'
+}
+
+/* One line of context per candidate image — how we found it, where it sat, how
+ * it was labeled. The image itself does most of the work; this catches the case
+ * where two candidates look alike (a mark vs. its og:image rendition, say). */
 const describeCandidate = (logo: LogoCandidate): string => {
-  const parts: string[] = [logo.kind === 'svg' ? 'inline SVG' : logo.kind]
+  const parts: string[] = [PROVENANCE[logo.kind] ?? logo.kind]
   if (logo.rect) {
     parts.push(
       `${logo.rect.width}x${logo.rect.height}px at (${logo.rect.left}, ${logo.rect.top}) on the page`
@@ -142,10 +158,10 @@ const describeCandidate = (logo: LogoCandidate): string => {
   return parts.join(', ')
 }
 
-/* Enough to always include the real mark (the probe's pre-rank only has to get
- * it into the top 8, not to #1), small enough that the vision call stays cheap
- * — the tiles are ≤256px. */
-const VISION_CANDIDATE_LIMIT = 8
+/* The probe quotas its pool to ~13 across three signal families; render all of
+ * them. The tiles are ≤256px, so the marginal cost of a candidate is small
+ * compared to the cost of the real logo missing its slot. */
+const VISION_CANDIDATE_LIMIT = 14
 
 const rasterizeCandidates = async (
   logos: LogoCandidate[]
@@ -159,11 +175,16 @@ const rasterizeCandidates = async (
   return rendered.filter((c): c is VisionLogoCandidate => c.png !== null)
 }
 
-/* When vision abstains or fails: a schema.org-declared logo is authoritative
- * (score >= 100 keeps Organization.logo and excludes the weaker
- * Organization.image entries that share the kind), an apple-touch-icon is
- * at least always the brand's own mark, and only then the heuristic top pick
- * — the ranking that shipped apple.com a nav glyph — gets a say. */
+/* When vision abstains or fails, walk the publisher-declared signals in
+ * descending precision before trusting any heuristic. A schema.org-declared
+ * logo is authoritative (score >= 100 keeps Organization.logo and excludes the
+ * weaker Organization.image entries that share the kind); manifest icons and
+ * apple-touch-icons are at least always the brand's own mark. Only then does
+ * the heuristic top pick — the ranking that shipped apple.com a nav glyph —
+ * get a say. og:image is deliberately absent: unlike the others it is often a
+ * hero photo, and only vision can tell. */
+const FALLBACK_KINDS = ['manifest', 'apple-touch-icon', 'tile', 'favicon']
+
 const fallbackLogoUrl = (
   logos: LogoCandidate[],
   rankedUrls: string[]
@@ -171,8 +192,12 @@ const fallbackLogoUrl = (
   const declared = logos.find(
     logo => logo.kind === 'ld+json' && logo.score >= 100
   )?.url
-  const touchIcon = logos.find(logo => logo.kind === 'apple-touch-icon')?.url
-  return declared ?? touchIcon ?? rankedUrls[0] ?? ''
+  if (declared) return declared
+  for (const kind of FALLBACK_KINDS) {
+    const match = logos.find(logo => logo.kind === kind)?.url
+    if (match) return match
+  }
+  return rankedUrls[0] ?? ''
 }
 
 /* Picks which widget header style the logo actually looks good on. Compares
@@ -350,22 +375,26 @@ export const detectBrand = async (
   // shipping an empty color, which quality.ts would replace with a generic blue.
   const primary = pick(finalColorPool, selection.primaryIndex) || finalColorPool[0]?.hex || ''
 
-  const visionPickedLogo =
+  const visionPicked =
     Number.isInteger(selection.logoIndex) &&
     selection.logoIndex >= 0 &&
     selection.logoIndex < logoCandidates.length
-      ? logoCandidates[selection.logoIndex].logo.url
+      ? logoCandidates[selection.logoIndex].logo
       : null
-  const logoUrl =
-    supplied.logoUrl ??
-    visionPickedLogo ??
-    fallbackLogoUrl(logos, finalLogoPool)
+  const chosenUrl =
+    supplied.logoUrl ?? visionPicked?.url ?? fallbackLogoUrl(logos, finalLogoPool)
 
   logger.info(
     `[brand ${input.companyId}] primary=${primary} ` +
-      `logo=${visionPickedLogo ? `vision-picked #${selection.logoIndex}` : logoUrl ? 'fallback chain' : 'none'} ` +
+      `logo=${visionPicked ? `vision-picked #${selection.logoIndex} (${visionPicked.kind})` : chosenUrl ? 'fallback chain' : 'none'} ` +
       `from ${finalColorPool.length} colors, ${logoCandidates.length}/${visionSourceLogos.length} logo candidates rendered`
   )
+
+  // A social-preview image is often the cleanest rendition of a mark but sits
+  // on a 1200x630 canvas; the widget header needs it cropped to the ink.
+  const logoUrl = chosenUrl
+    ? await trimLogoForDisplay(chosenUrl, input.companyId)
+    : ''
 
   const brandColor = supplied.brandColor ?? primary
   return {

--- a/apps/demo-setup/src/pipeline/rasterize-logo.ts
+++ b/apps/demo-setup/src/pipeline/rasterize-logo.ts
@@ -1,4 +1,5 @@
 import sharp from 'sharp'
+import { logger } from '../lib/logger'
 import { fetchImageBuffer } from './sample-logo-color'
 
 /* Renders a logo candidate to a small PNG the vision model can actually look
@@ -31,5 +32,70 @@ export const rasterizeLogoCandidate = async (
     // .ico favicons, corrupt images, unsupported formats — drop the candidate
     // rather than failing brand detection over it.
     return null
+  }
+}
+
+/* The widget renders logoUrl directly in its header, so the chosen asset has to
+ * be *tight*. Social-preview images (og:image) are the cleanest rendition of a
+ * mark on many sites but are drawn on a 1200x630 canvas — used as-is, the mark
+ * renders as a speck in a sea of white. Crop the uniform border away and inline
+ * the result, which also frees the widget from hotlinking the prospect's CDN.
+ *
+ * Only worth it when the crop actually reclaims meaningful area; a header logo
+ * is already tight, and re-encoding it as a data URI would only cost bytes. */
+const DISPLAY_MAX_EDGE = 512
+const TRIM_THRESHOLD = 10
+// Below this fraction of the original area retained, the trim earned its keep.
+const WORTHWHILE_AREA_RATIO = 0.85
+// A data URI beyond this is worse than hotlinking; the widget inlines it into
+// the page's config blob.
+const MAX_DATA_URI_BYTES = 96_000
+
+export const trimLogoForDisplay = async (
+  url: string,
+  companyId: string
+): Promise<string> => {
+  // Inline SVGs are vector and already tightly bounded by their viewBox.
+  if (url.startsWith('data:')) return url
+
+  const buffer = await fetchImageBuffer(url)
+  if (!buffer) return url
+
+  try {
+    const original = await sharp(buffer).metadata()
+    if (!original.width || !original.height) return url
+
+    // Measure the crop before any resize, so the ratio compares like with like.
+    // Transparency is preserved: a mark drawn as white ink on a transparent
+    // background must not be flattened onto white and then trimmed to nothing.
+    const trimmed = await sharp(buffer)
+      .trim({ threshold: TRIM_THRESHOLD })
+      .png()
+      .toBuffer({ resolveWithObject: true })
+
+    const retained =
+      (trimmed.info.width * trimmed.info.height) /
+      (original.width * original.height)
+    // A uniform image trims to nothing; a tight one trims to ~itself.
+    if (retained < 0.001 || retained > WORTHWHILE_AREA_RATIO) return url
+
+    const resized = await sharp(trimmed.data)
+      .resize(DISPLAY_MAX_EDGE, DISPLAY_MAX_EDGE, {
+        fit: 'inside',
+        withoutEnlargement: true
+      })
+      .png()
+      .toBuffer()
+
+    const dataUri = `data:image/png;base64,${resized.toString('base64')}`
+    if (dataUri.length > MAX_DATA_URI_BYTES) return url
+
+    logger.info(
+      `[brand ${companyId}] trimmed logo padding: ${original.width}x${original.height} → ${trimmed.info.width}x${trimmed.info.height}`
+    )
+    return dataUri
+  } catch {
+    // A logo we can't decode is still a logo the browser probably can.
+    return url
   }
 }

--- a/apps/demo-setup/src/types.ts
+++ b/apps/demo-setup/src/types.ts
@@ -99,6 +99,12 @@ export type BrandProbe = {
   logos?: {
     url: string
     kind: string
+    // Which signal family the candidate came from. The probe quotas slots per
+    // class rather than globally score-sorting, since scores across families
+    // aren't comparable. 'structured' = publisher-declared (schema.org logo,
+    // og:image, manifest icon, apple-touch-icon); 'dom' = found by walking the
+    // page; 'recurrence' = repeats across scraped pages.
+    sourceClass?: 'structured' | 'dom' | 'recurrence'
     area?: number
     score: number
     rect?: PixelRect


### PR DESCRIPTION
## Why

Companion to [web-crawler#20](https://github.com/Untap-AI/web-crawler/pull/20). The probe now emits candidates in three signal families (`structured` / `dom` / `recurrence`) with a per-family quota rather than a global top-N by score, because scores across families aren't comparable — that's what let eight "recurring" nav glyphs evict apple.com's real mark before vision ever saw it.

## What

- **Render the whole quota'd pool** for vision (limit 8 → 14) and **caption each candidate with its provenance**. "Declared by the site as its logo (schema.org)" is a far stronger prior than "an image found on the page" — but not a certainty, so the model is told to sanity-check it by looking.
- **`og:image` is offered to vision but kept out of the non-vision fallback chain.** It's the signal that solves apple.com (Apple serves its real mark there), but it's frequently a hero or marketing shot, and only vision can tell the difference. The fallback now walks `manifest → apple-touch-icon → tile → favicon` before conceding to the heuristic top pick.
- **Trim logo padding before display.** Social-preview images are drawn on a 1200×630 canvas; used as-is, the mark renders as a speck in a sea of white. `trimLogoForDisplay` crops the uniform border and inlines the result (Apple: `1200x630 → 199x231`), which also stops the widget hotlinking a prospect's CDN. Skipped for inline SVGs (already tight) and when the crop reclaims little area.

## Verification

8 live scrapes at the **production page count (8)** — the exact config that broke the last fix, which I'd only tested at 3 pages:

| Site | Detected logo | Notes |
|---|---|---|
| apple.com | Apple mark | was "TV & Home" |
| stripe.com | Stripe wordmark | |
| notion.com | Notion "N" | |
| linear.app | Linear lockup | white ink → primary theme |
| allbirds.com | allbirds wordmark | monochrome brand |
| pizzeriabianco.com | BIANCO wordmark | white ink; trimmed 750×201 → 625×78 |
| bendbrewingco.com | circular seal | recurrence-only find |
| westhillsvineyards.com | horse emblem | the original miss |

**8/8 correct.** All vision-picked; none reached the fallback chain. Picks identical across two independent runs. Each logo was rendered on the header background the widget actually chose for it and inspected visually — including the two white-ink marks, which only read correctly on their colored ground.

`tsc --noEmit` + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
