### PR TITLE
feat(demo-setup): add conversion CTA to demo page, raise crawl depth

### DIFF
--- a/apps/demo-setup/.env.example
+++ b/apps/demo-setup/.env.example
@@ -42,9 +42,14 @@ API_BASE_URL_TEST=https://dialogue-foundry-backend-smokebox-swjv.onrender.com/ap
 CRAWLER_DIR=/Users/Peyton/Projects/web-crawler
 # Python interpreter to use (point at the crawler's venv for installed deps)
 CRAWLER_PYTHON=python3
-# Crawl depth for production vs test demos (background crawl only)
-CRAWLER_MAX_DEPTH_PROD=0
-CRAWLER_MAX_DEPTH_TEST=0
+# Crawl depth for production vs test demos (background crawl only).
+# 0 = homepage only, 1 = pages linked off the homepage, 2 = one hop further
+# (a menu linked from a menus index, a service detail page).
+CRAWLER_MAX_DEPTH_PROD=2
+CRAWLER_MAX_DEPTH_TEST=2
+# Hard cap on pages the deep crawl visits, so depth 2 on a link-heavy site can't
+# balloon.
+CRAWLER_MAX_PAGES=100
 # Max pages the shallow demo-prep scrape reads for content analysis
 SCRAPE_MAX_PAGES=5
 # Run crawl4ai's Chrome headless (no visible browser windows during scrape/crawl)

--- a/apps/demo-setup/src/config/env.ts
+++ b/apps/demo-setup/src/config/env.ts
@@ -69,6 +69,12 @@ export const env = {
   demoBucket: optional('DEMO_S3_BUCKET', 'demo.untap-ai.com'),
   demoBaseUrl: optional('DEMO_BASE_URL', 'https://demo.untap-ai.com'),
 
+  // Where the demo page's footer CTA sends a prospect who wants the widget on
+  // their own site. The demo page is otherwise a dead end — the only conversion
+  // path was replying to the "demo ready" email.
+  demoCtaUrl: optional('DEMO_CTA_URL', 'https://untap-ai.com/pricing'),
+  demoCtaEmail: optional('DEMO_CTA_EMAIL', 'contact@untap-ai.com'),
+
   widgetScriptUrl: optional(
     'WIDGET_SCRIPT_URL',
     'https://djwdzs5n3r4m2.cloudfront.net/0.4/index.js'
@@ -86,14 +92,18 @@ export const env = {
 
   crawlerDir: () => required('CRAWLER_DIR'),
   crawlerPython: optional('CRAWLER_PYTHON', 'python3'),
+  // Depth 1 only reaches pages linked directly off the homepage. Depth 2 picks
+  // up the next hop (a menu linked from a menus index, a service detail page),
+  // which is where specifics tend to live. Safe to raise now that the page cap
+  // below is actually enforced by the crawler.
   crawlerMaxDepth: (isProd: boolean) =>
     isProd
-      ? optional('CRAWLER_MAX_DEPTH_PROD', '1')
-      : optional('CRAWLER_MAX_DEPTH_TEST', '1'),
+      ? optional('CRAWLER_MAX_DEPTH_PROD', '2')
+      : optional('CRAWLER_MAX_DEPTH_TEST', '2'),
   // Hard cap on pages visited by the deep RAG crawl. Depth alone isn't a bound —
-  // depth 1 on a site with a large footer nav could otherwise be hundreds of
+  // depth 2 on a site with a large footer nav could otherwise be hundreds of
   // pages.
-  crawlerMaxPages: optional('CRAWLER_MAX_PAGES', '50'),
+  crawlerMaxPages: optional('CRAWLER_MAX_PAGES', '100'),
 
   // Number of pages the shallow demo-prep scrape fetches (homepage + internal
   // links, ranked by relevance — see web-crawler/scrape_page.py's PATH_PRIORITIES).

--- a/apps/demo-setup/src/pipeline/build-html.ts
+++ b/apps/demo-setup/src/pipeline/build-html.ts
@@ -79,19 +79,92 @@ const renderFontLinks = (fontLinkHref: string | null): string =>
   <link rel="stylesheet" href="${fontLinkHref}" />`
     : ''
 
-const renderHtml = (config: WidgetConfig, fontLinkHref: string | null): string =>
+// companyName reaches here from an LLM reading scraped web content, so it can't
+// be trusted into markup unescaped.
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+
+/* The demo page is otherwise an empty page hosting a chat widget: a prospect who
+ * comes back to it later has no way to say yes without digging up our email.
+ * This is the only conversion path on the page itself, so it stays visible
+ * rather than being another thing to click open. Deliberately styled in Untap's
+ * own colors, not the prospect's brand — it's us talking, not their site. */
+const renderCta = (companyName: string | undefined): string => {
+  const site = companyName ? escapeHtml(companyName) : 'your site'
+
+  return `  <footer class="untap-cta">
+    <div class="untap-cta__text">
+      <strong>This assistant was built for ${site} by Untap AI.</strong>
+      <span>Put it on your real site and it answers questions and captures leads around the clock.</span>
+    </div>
+    <div class="untap-cta__actions">
+      <a class="untap-cta__button" href="${env.demoCtaUrl}">Get this on my site</a>
+      <a class="untap-cta__link" href="mailto:${env.demoCtaEmail}">Talk to us</a>
+    </div>
+  </footer>`
+}
+
+const CTA_STYLES = `    :root { color-scheme: light dark; }
+    body { margin: 0; min-height: 100vh; display: flex; flex-direction: column; }
+    #root { flex: 1 0 auto; }
+    .untap-cta {
+      flex-shrink: 0;
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px 24px;
+      /* Extra right padding keeps the actions clear of the widget's floating
+       * launcher, which is fixed to the bottom-right corner and would otherwise
+       * sit on top of them. */
+      padding: 20px 96px 20px 24px;
+      background: #0f1222;
+      color: #ffffff;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
+    }
+    .untap-cta__text { display: flex; flex-direction: column; gap: 4px; }
+    .untap-cta__text strong { font-size: 15px; font-weight: 600; }
+    .untap-cta__text span { font-size: 14px; color: #b6bad0; }
+    .untap-cta__actions { display: flex; align-items: center; gap: 16px; }
+    .untap-cta__button {
+      background: #465cff;
+      color: #ffffff;
+      padding: 10px 18px;
+      border-radius: 8px;
+      font-size: 14px;
+      font-weight: 600;
+      text-decoration: none;
+      white-space: nowrap;
+    }
+    .untap-cta__button:hover { background: #3549e0; }
+    .untap-cta__link { color: #b6bad0; font-size: 14px; text-decoration: none; white-space: nowrap; }
+    .untap-cta__link:hover { color: #ffffff; }`
+
+const renderHtml = (
+  config: WidgetConfig,
+  fontLinkHref: string | null,
+  companyName: string | undefined
+): string =>
   `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Dialogue Foundry Chat Playground</title>${renderFontLinks(fontLinkHref)}
+  <style>
+${CTA_STYLES}
+  </style>
   <script id="dialogue-foundry-config" type="application/json">
 ${escapeForInlineScript(JSON.stringify(config, undefined, 2))}
   </script>
 </head>
 <body>
   <div id="root"></div>
+${renderCta(companyName)}
   <script type="module" src="${env.widgetScriptUrl}"></script>
 </body>
 </html>`
@@ -104,4 +177,9 @@ export const buildHtml = (
   input: PreparedInput,
   analysis: ContentAnalysis,
   brand: BrandResult
-): string => renderHtml(buildConfig(input, analysis, brand), brand.fontLinkHref)
+): string =>
+  renderHtml(
+    buildConfig(input, analysis, brand),
+    brand.fontLinkHref,
+    input.companyName
+  )


### PR DESCRIPTION
## 1. Demo page had no conversion path

The generated demo page was a bare `<div id="root">` hosting the chat widget and nothing else. A prospect who liked the demo and came back to it later had **no way to act on it** — the only route to us was replying to the "demo ready" email.

Adds a footer CTA: a "Get this on my site" button (→ pricing) and a "Talk to us" mail link. Deliberately styled in Untap's colours rather than the prospect's brand, since it's us talking, not their site. Both targets are configurable (`DEMO_CTA_URL`, `DEMO_CTA_EMAIL`).

`companyName` is interpolated into markup and originates from an LLM reading scraped web content, so it's HTML-escaped.

### Rendered

Verified by rendering a real config (Café Renaissance) and screenshotting. First pass had the widget's floating launcher sitting on top of the "Talk to us" link — the footer now reserves right padding to clear it. Checked at 1200px and 390px.

## 2. Crawl depth

Raises the deep-crawl depth default `1` → `2` and the page cap `50` → `100`.

Depth 1 only reaches pages linked directly off the homepage. Depth 2 picks up the next hop — a menu linked from a menus index, a service detail page — which is where the specifics prospects actually ask about tend to live. Safe to raise now that the crawler genuinely enforces `max_pages` (it previously passed `MAX_PAGES` to a crawler that ignored it, leaving depth as the only bound).

`.env.example` also carried `CRAWLER_MAX_DEPTH_PROD=0` / `_TEST=0` — homepage only — so any fresh setup copying it would produce a demo chatbot that knows nothing but the landing page. Fixed, with a comment explaining what each depth level actually reaches.

## Note

Production values live in the Mac Mini's `.env` (`CRAWLER_MAX_DEPTH_PROD=1`, `CRAWLER_MAX_PAGES=25`), which override these code defaults. **Merging this alone won't change production behaviour** — that file needs updating separately.

This is a quality improvement, not the fix for the three-chunk bug reported against Café Renaissance's demo. That root cause was `is_file_url` in the crawler discarding `.html` pages, fixed in Untap-AI/web-crawler#21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)