### PR TITLE
chore: version frontend 0.4.71 to redeploy with fixed VITE_API_BASE_URL

### DIFF
--- a/apps/frontend/CHANGELOG.md
+++ b/apps/frontend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @dialogue-foundry/frontend
 
+## 0.4.71
+
+### Patch Changes
+
+- No functional code change — forces a rebuild/republish of the `0.4/index.js` CDN bundle so it picks up the corrected `VITE_API_BASE_URL` build secret (was missing the `/api` path segment, which broke every request `fetchWidgetConfigFromBackend`/`useChatAvailability`/`useChatPersistence` make for the new minimal `#dialogue-foundry-widget` embed path added in 0.4.70).
+
 ## 0.4.70
 
 ### Patch Changes

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dialogue-foundry/frontend",
   "private": true,
-  "version": "0.4.70",
+  "version": "0.4.71",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Empty version-only patch bump (0.4.70 → 0.4.71) to force the `publish-packages` workflow to rebuild and republish the `0.4/index.js` CDN bundle.
- No functional code change. The rebuild is needed because `VITE_API_BASE_URL` (a new CI secret wired up in #90) was baked into the bundle without its `/api` suffix, breaking every request the new minimal `#dialogue-foundry-widget` embed makes (widget-config, chats, availability, events). The secret has already been corrected via `gh secret set`; this PR just triggers the rebuild that bakes the fix in.
- Related: production backend (`dialogue-foundry-backend-v2-test.onrender.com`) also still needs a manual Render deploy to pick up the new `/api/widget-config/:companyId` route from #90 — `autoDeploy` is off for that service, so merging this alone won't fix the demo end-to-end.

## Test plan
- [ ] Merge, confirm `Publish Packages` workflow succeeds and invalidates CloudFront
- [ ] `curl https://djwdzs5n3r4m2.cloudfront.net/0.4/index.js | grep dialogue-foundry-backend` and confirm the baked-in URL now ends in `/api`
- [ ] After the backend is also manually redeployed on Render, reload the `demo-gtlandscapesolutions-2a8a7056` demo page and confirm custom branding (logo, welcome message, suggestions, theme) loads instead of defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)